### PR TITLE
Use new-style classes

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -12,7 +12,7 @@ from clarity_ext.result_file import ResultFile
 from clarity_ext.utils import lazyprop
 
 
-class ExtensionContext:
+class ExtensionContext(object):
     """
     Defines context objects for extensions.
     """
@@ -234,7 +234,7 @@ class MatchedAnalytes:
         return list(input_analytes), list(output_analytes)
 
 
-class Advanced:
+class Advanced(object):
     """Provides advanced features, should be avoided in extension scripts"""
     def __init__(self, lims):
         self.lims = lims

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -1,7 +1,7 @@
 from domain import *
 
 
-class Dilute:
+class Dilute(object):
     # Enclose sample data, user input and derived variables for a
     # single row in a dilution
     def __init__(self, input_analyte, output_analyte):
@@ -22,7 +22,7 @@ class Dilute:
         self.has_to_evaporate = None
 
 
-class RobotDeckPositioner:
+class RobotDeckPositioner(object):
     """
     Handle plate positions on the robot deck (target and source)
     as well as well indexing
@@ -87,7 +87,7 @@ class RobotDeckPositioner:
 PLATE_TYPE_96_WELL = 1
 
 
-class DilutionScheme:
+class DilutionScheme(object):
     """Creates a dilution scheme, given input and output analytes."""
 
     def __init__(self, matched_analytes, robot_name, plate):

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -1,7 +1,7 @@
 from clarity_ext.domain.container import PlatePosition, Well
 
 
-class Analyte:
+class Analyte(object):
     """
     Describes an Analyte in the Clarity LIMS system, including custom UDFs.
 

--- a/clarity_ext/domain/container.py
+++ b/clarity_ext/domain/container.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from clarity_ext.utils import lazyprop
 
 
-class Well:
+class Well(object):
     """Encapsulates a well in a plate"""
     def __init__(self, position, plate, artifact_name=None, artifact_id=None):
         self.position = position
@@ -65,7 +65,7 @@ class PlateSize(namedtuple("PlateSize", ["height", "width"])):
     pass
 
 
-class Container:
+class Container(object):
     """Encapsulates a Container"""
 
     DOWN_FIRST = 1
@@ -154,7 +154,7 @@ class Container:
         self.wells[well_pos].artifact_id = artifact_id
 
 
-class Plate:
+class Plate(object):
     """Encapsulates a Plate"""
 
     DOWN_FIRST = 1

--- a/clarity_ext/domain/validation.py
+++ b/clarity_ext/domain/validation.py
@@ -3,7 +3,7 @@ class ValidationType:
     WARNING = 2
 
 
-class ValidationException:
+class ValidationException(object):
     def __init__(self, msg, validation_type=ValidationType.ERROR):
         self.msg = msg
         self.type = validation_type

--- a/clarity_ext/driverfile.py
+++ b/clarity_ext/driverfile.py
@@ -5,7 +5,7 @@ from genologics.epp import attach_file
 from genologics.entities import *
 
 
-class DriverFileService:
+class DriverFileService(object):
     def __init__(self, extension, result_path, logger=None):
         self.logger = logger or logging.getLogger(__name__)
         self.extension = extension
@@ -71,7 +71,7 @@ class DriverFileService:
             print "---"
 
 
-class DriverFileIntegrationTests:
+class DriverFileIntegrationTests(object):
     @staticmethod
     def _locate_driver_file_pair(run_directory, frozen_directory, test):
         def locate_driver_file(path):

--- a/clarity_ext/extensions.py
+++ b/clarity_ext/extensions.py
@@ -21,7 +21,7 @@ from clarity_ext.context import ClarityService
 # TODO: use Python 3 and add typing hints
 
 
-class ExtensionService:
+class ExtensionService(object):
 
     RUN_MODE_TEST = "test"
     RUN_MODE_FREEZE = "freeze"
@@ -194,7 +194,7 @@ class ResultsDifferFromFrozenData(Exception):
     pass
 
 
-class RunDirectoryInfo:
+class RunDirectoryInfo(object):
     """
     Provides methods to query a particular result directory for its content
 
@@ -246,7 +246,7 @@ class RunDirectoryInfo:
                 yield ("uploaded", key, "".join(diff[0:10]))
 
 
-class GeneralExtension:
+class GeneralExtension(object):
     """
     An extension that must implement the `execute` method
     """
@@ -303,7 +303,7 @@ class DriverFileExtension(GeneralExtension):
             raise ValueError("Validation errors: ".format(os.path.sep.join(report)))
 
 
-class ExtensionTest:
+class ExtensionTest(object):
     def __init__(self, pid):
         self.pid = pid
 

--- a/clarity_ext/integration.py
+++ b/clarity_ext/integration.py
@@ -7,7 +7,7 @@ from driverfile import DriverFileIntegrationTests
 
 # Creates an integration test config file based on convention
 # i.e. position and contents of the script classes themselves.
-class ConfigFromConventionProvider:
+class ConfigFromConventionProvider(object):
 
     @classmethod
     def _enumerate_modules(cls, root_name):
@@ -33,7 +33,7 @@ class ConfigFromConventionProvider:
             yield entry
 
 
-class IntegrationTestService:
+class IntegrationTestService(object):
     CACHE_NAME = "test_run_cache"
 
     def __init__(self, logger=None):

--- a/clarity_ext/pdf.py
+++ b/clarity_ext/pdf.py
@@ -1,7 +1,7 @@
 from PyPDF2 import PdfFileReader, PdfFileWriter
 
 
-class PdfSplitter:
+class PdfSplitter(object):
     def __init__(self, stream):
         self._stream = stream
         self._input_pdf = PdfFileReader(self._stream)

--- a/clarity_ext/result_file.py
+++ b/clarity_ext/result_file.py
@@ -1,4 +1,4 @@
-class ResultFile:
+class ResultFile(object):
     """Encapsulates a ResultFile in Clarity"""
     def __init__(self, api_resource, units):
         self.api_resource = api_resource

--- a/clarity_ext/unit_conversion.py
+++ b/clarity_ext/unit_conversion.py
@@ -2,7 +2,7 @@ import math
 import logging
 
 
-class UnitConversion:
+class UnitConversion(object):
     NANO = -9
     PICO = -12
 

--- a/clarity_ext/utility/hamilton_driver_file_reader.py
+++ b/clarity_ext/utility/hamilton_driver_file_reader.py
@@ -1,4 +1,4 @@
-class HamiltonReader:
+class HamiltonReader(object):
 
     def __init__(self, filecontents):
         self._delimiter = "\t"
@@ -14,7 +14,7 @@ class HamiltonReader:
         return len(self.matrix)
 
 
-class HamiltonColumnReference:
+class HamiltonColumnReference(object):
 
     def __init__(self):
         self.sample = 0


### PR DESCRIPTION
- All classes in clarity_ext should be new-style (inherit from object).
  This is the default in py3.