### PR TITLE
Rename ClarityService to ClaritySession and move it

### DIFF
--- a/clarity_ext/__init__.py
+++ b/clarity_ext/__init__.py
@@ -1,1 +1,2 @@
 from clarity_ext.unit_conversion import UnitConversion
+from clarity_ext.clarity import ClaritySession

--- a/clarity_ext/clarity.py
+++ b/clarity_ext/clarity.py
@@ -1,0 +1,18 @@
+from genologics.lims import Lims
+from genologics.config import BASEURI, USERNAME, PASSWORD
+from genologics.entities import Process
+
+
+class ClaritySession(object):
+    """
+    A wrapper around connections to Clarity.
+    """
+    def __init__(self, api, current_step):
+        self.api = api
+        api.check_version()
+        self.current_step = Process(self.api, id=current_step)
+
+    @staticmethod
+    def create(current_step):
+        return ClaritySession(Lims(BASEURI, USERNAME, PASSWORD), current_step)
+

--- a/clarity_ext/clarity.py
+++ b/clarity_ext/clarity.py
@@ -7,12 +7,12 @@ class ClaritySession(object):
     """
     A wrapper around connections to Clarity.
     """
-    def __init__(self, api, current_step):
+    def __init__(self, api, current_step_id):
         self.api = api
         api.check_version()
-        self.current_step = Process(self.api, id=current_step)
+        self.current_step = Process(self.api, id=current_step_id)
 
     @staticmethod
-    def create(current_step):
-        return ClaritySession(Lims(BASEURI, USERNAME, PASSWORD), current_step)
+    def create(current_step_id):
+        return ClaritySession(Lims(BASEURI, USERNAME, PASSWORD), current_step_id)
 

--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -16,23 +16,23 @@ class ExtensionContext(object):
     """
     Defines context objects for extensions.
     """
-    def __init__(self, logger=None, cache=False, clarity_svc=None):
+    def __init__(self, logger=None, cache=False, session=None):
         """
         Initializes the context.
 
         :param logger: A logger instance
         :param cache: Set to True to use the cache folder (.cache) for downloaded files
-        :param clarity_svc: A LimsService object, encapsulates connections to the Clarity application server
+        :param session: An object encapsulating the connection to Clarity
         """
-
-        self.advanced = Advanced(clarity_svc.api)
+        self.session = session
+        self.advanced = Advanced(session.api)
         self.logger = logger or logging.getLogger(__name__)
         self._local_shared_files = []
         self.cache = cache
 
         self.units = UnitConversion(self.logger)
         self._update_queue = []
-        self.current_step = clarity_svc.current_step
+        self.current_step = session.current_step
 
     def local_shared_file(self, file_name, mode='r'):
         """
@@ -245,12 +245,4 @@ class Advanced(object):
         """
         url = "{}/api/v2/{}".format(BASEURI, endpoint)
         return requests.get(url, auth=(USERNAME, PASSWORD))
-
-
-class ClarityService:
-    """A wrapper around connections to the lims. Provided for testability"""
-    def __init__(self, api, current_step):
-        self.api = api
-        api.check_version()
-        self.current_step = Process(self.api, id=current_step)
 

--- a/clarity_ext/extensions.py
+++ b/clarity_ext/extensions.py
@@ -10,9 +10,7 @@ import logging
 import difflib
 import re
 from clarity_ext.utils import lazyprop
-from genologics.config import BASEURI, USERNAME, PASSWORD
-from genologics.lims import Lims
-from clarity_ext.context import ClarityService
+from clarity_ext import ClaritySession
 
 
 # Defines all classes that are expected to be extended. These are
@@ -142,8 +140,8 @@ class ExtensionService(object):
 
                 self.logger.info("Executing at {}".format(path))
 
-                clarity_svc = ClarityService(Lims(BASEURI, USERNAME, PASSWORD), run_arguments["pid"])
-                context = ExtensionContext(cache=cache_artifacts, clarity_svc=clarity_svc)
+                session = ClaritySession.create(run_arguments["pid"])
+                context = ExtensionContext(cache=cache_artifacts, session=session)
 
                 if issubclass(extension, DriverFileExtension):
                     instance = extension(context)


### PR DESCRIPTION
- The ClarityService class really encapsulates a session. Name it
  accordingly