### PR TITLE
Add a repository for analytes in the current step

### DIFF
--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -1,4 +1,4 @@
-from clarity_ext.domain.container import PlatePosition, Well
+from clarity_ext.domain.container import PlatePosition, Well, Container
 
 
 class Analyte(object):
@@ -8,9 +8,12 @@ class Analyte(object):
     Takes an analyte resource as input.
     """
 
-    def __init__(self, resource, plate):
+    def __init__(self, resource, container):
+        """
+        :resource: The API resource
+        """
         self.resource = resource
-        self.plate = plate
+        self.container = container
 
     # Mapped properties from the underlying resource
     @property
@@ -34,11 +37,7 @@ class Analyte(object):
     @property
     def well(self):
         pos = PlatePosition.create(self.resource.location[1])
-        return Well(pos, self.plate)
-
-    @property
-    def container(self):
-        return self.resource.location[0]
+        return Well(pos, self.container)
 
     @property
     def sample(self):
@@ -46,4 +45,10 @@ class Analyte(object):
 
     def __repr__(self):
         return "{} ({})".format(self.name, self.sample.id)
+
+    @staticmethod
+    def create_from_rest_resource(artifact):
+        container_resource = artifact.location[0]
+        container = Container.create_from_rest_resource(container_resource, [])
+        return Analyte(artifact, container)
 

--- a/clarity_ext/domain/artifact.py
+++ b/clarity_ext/domain/artifact.py
@@ -1,0 +1,49 @@
+from clarity_ext.domain import Analyte
+from clarity_ext.domain import Container
+
+
+class StepInputOutputMapRepository(object):
+    """
+    The REST API provides `Artifact`s. These are wrapped as other domain objects.
+    """
+    def __init__(self, session):
+        self.session = session
+
+    def all_analytes(self):
+        """
+        Fetches a tuple of (input_analytes, output_analytes). They are in sorted order.
+        """
+        inputs, outputs = self.all_artifacts()
+
+        def sorted_analytes(seq):
+            return sorted(filter(lambda x: isinstance(x, Analyte), seq), key=lambda entry: entry.sample.id)
+
+        input_analytes = sorted_analytes(inputs)
+        output_analytes = sorted_analytes(outputs)
+        return input_analytes, output_analytes
+
+    def all_artifacts(self):
+        """Returns all artifacts in the current step. All have been mapped to domain objects.
+
+        NOTE: For simplicity, this fetches the entire input output map, including
+        batch fetching. This will lead to more calls than needed in many cases
+        but makes development much simpler. Will be optimized later if needed.
+        """
+        # TODO: Uses two calls, could use the input output map directly:
+        inputs = self.session.current_step.all_inputs(unique=True, resolve=True)
+        outputs = self.session.current_step.all_outputs(unique=True, resolve=True)
+
+        inputs = list(self._wrap_artifacts(inputs))
+        outputs = list(self._wrap_artifacts(outputs))
+        return inputs, outputs
+
+    def _wrap_artifacts(self, artifacts):
+        """
+        Wraps an artifact in a domain object, if one exists. The domain objects provide logic
+        convenient methods for working with the domain object in extensions.
+        """
+        for artifact in artifacts:
+            if artifact.type == "Analyte":
+                yield Analyte.create_from_rest_resource(artifact)
+            else:
+                yield artifact

--- a/clarity_ext/domain/artifact.py
+++ b/clarity_ext/domain/artifact.py
@@ -2,9 +2,11 @@ from clarity_ext.domain import Analyte
 from clarity_ext.domain import Container
 
 
-class StepInputOutputMapRepository(object):
+class StepRepository(object):
     """
-    The REST API provides `Artifact`s. These are wrapped as other domain objects.
+    Provides access to data that's available through a current step.
+
+    All methods return the domain objects, wrapping the REST resources.
     """
     def __init__(self, session):
         self.session = session

--- a/clarity_ext/domain/container.py
+++ b/clarity_ext/domain/container.py
@@ -82,23 +82,26 @@ class Container(object):
         """
         self.mapping = mapping
         self.container_type = container_type
-        self.size = None
+        self.id = None
 
         if self.container_type == self.CONTAINER_TYPE_96_WELLS_PLATE:
             self.size = PlateSize(height=8, width=12)
         elif self.container_type == self.CONTAINER_TYPE_STRIP_TUBE:
             self.size = PlateSize(height=8, width=1)
         else:
-            self.size = None
+            raise ValueError("Unknown plate type '{}'".format(self.container_type))
 
     @classmethod
     def create_from_rest_resource(cls, resource, artifacts):
         """
-        Creates a container based on a resource from the REST API
+        Creates a container based on a resource from the REST API.
         """
         # TODO: This needs to be cleaned up, i.e. how exactly the rest resource and domain objects should interact
-        ret = Container()
-        ret.rest_resource = resource
+        if resource.type.name == "96 well plate":
+            ret = Container(container_type=Container.CONTAINER_TYPE_96_WELLS_PLATE)
+        else:
+            raise NotImplementedError("Resource type '{}' is not supported".format(resource.type.name))
+        ret.id = resource.id
         ret.size = PlateSize(width=resource.type.x_dimension["size"], height=resource.type.y_dimension["size"])
         for artifact in artifacts:
             ret.set_well(artifact.location[1], artifact.name, artifact.id)

--- a/test/integration/domain/test_artifact.py
+++ b/test/integration/domain/test_artifact.py
@@ -1,0 +1,55 @@
+import unittest
+from clarity_ext.domain.artifact import StepInputOutputMapRepository
+from clarity_ext.clarity import ClaritySession
+import itertools
+
+
+class TestIntegrationAnalyteRepository(unittest.TestCase):
+    """
+    Tests that validate if the analyte repository works as expected, giving confidence in
+    unit tests that use this class.
+
+    Requires steps in a certain condition.
+    """
+
+    def test_placed_samples(self):
+        """
+        Required setup:
+          - Step 24-3643 (TODO: configurable) has placed samples on 96 well plates
+          - Input:
+            - Plate1: D5
+            - Plate2: A5, B7, E12
+          - Output:
+            - Plate1: B5, D6
+            - Plate2: A3, E9
+        """
+        session = ClaritySession.create("24-3643")
+        repo = StepInputOutputMapRepository(session)
+        inputs, outputs = repo.all_analytes()
+
+        self.assertEqual(len(outputs), len(inputs), "Expected same number of inputs and outputs")
+        self.assertEqual([input.sample.id for input in inputs],
+                         [output.sample.id for output in outputs],
+                         "Expected inputs and outputs to be in the same order")
+
+        def group_analytes(analytes):
+            keyfunc = lambda analyte: analyte.container.id
+            grouped = itertools.groupby(sorted(analytes, key=keyfunc), key=keyfunc)
+            return {key: set(x.well.position.__repr__() for x in value) for key, value in grouped}
+
+        actual_inputs = group_analytes(inputs)
+        expected_inputs = {
+            "27-629": set(["B:7", "E:12", "A:5"]),
+            "27-628": set(["D:5"]),
+        }
+        self.assertEqual(expected_inputs, actual_inputs)
+
+        # TODO: Uses non-constant container names
+        actual_outputs = group_analytes(outputs)
+        expected_outputs = {
+            "27-630": set(["B:5", "D:6"]),
+            "27-631": set(["A:3", "E:9"]),
+        }
+
+        self.assertEqual(expected_outputs, actual_outputs)
+

--- a/test/integration/domain/test_artifact.py
+++ b/test/integration/domain/test_artifact.py
@@ -1,5 +1,5 @@
 import unittest
-from clarity_ext.domain.artifact import StepInputOutputMapRepository
+from clarity_ext.domain.artifact import StepRepository
 from clarity_ext.clarity import ClaritySession
 import itertools
 
@@ -24,7 +24,7 @@ class TestIntegrationAnalyteRepository(unittest.TestCase):
             - Plate2: A3, E9
         """
         session = ClaritySession.create("24-3643")
-        repo = StepInputOutputMapRepository(session)
+        repo = StepRepository(session)
         inputs, outputs = repo.all_analytes()
 
         self.assertEqual(len(outputs), len(inputs), "Expected same number of inputs and outputs")


### PR DESCRIPTION
- Fetch the `Analyte` domain objects through a repository only.
  Don't access it directly through the REST API. This makes it possible
  to mock this repository only when unit testing classes that use it.
- Stop sending in a `Plate` object
- Remove the MatchedAnalytes class, replace it with sorting logic in the
  repository
- Update the dilutes module in relation to this
- Use the Container rather than the Plate object.
- Provide a resource when creating the domain `Container` object.