### PR TITLE
Run test coverage when running the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ run-test/
 *.swp
 int_tests/
 .virtualenv
+.coverage
+cover/
 

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,0 +1,3 @@
+# Format all files according to PEP8, based on changes from the develop branch
+pep8radius --in-place develop
+

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 # Add that to the dev reqs file for now, since it's not needed when running
 dependencies = ['click', 'genologics', 'requests-cache', 'pyyaml', 'nose', 'PyPDF2',
-                'lxml']
+                'lxml', 'coverage', 'pep8radius']
 
 setup(
     name='clarity-ext',

--- a/test/unit/clarity_ext/test_utils.py
+++ b/test/unit/clarity_ext/test_utils.py
@@ -1,0 +1,29 @@
+import unittest
+from mock import Mock
+from clarity_ext.utils import lazyprop
+
+
+class UsesLazyProp:
+    """This class is only used in the tests"""
+
+    def __init__(self, fn):
+        self.fn = fn
+
+    @lazyprop
+    def lazy_prop(self):
+        return self.fn()
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_lazy_prop_called_once(self):
+        """
+        Ensures that the lazy property is called only once, but returns the same value.
+        """
+        mock = Mock(return_value=100)
+        prop = UsesLazyProp(mock)
+        val1 = prop.lazy_prop
+        val2 = prop.lazy_prop
+        self.assertEqual(val1, 100)
+        self.assertEqual(val1, val2)
+        mock.assert_called_once()

--- a/validate-integration.sh
+++ b/validate-integration.sh
@@ -2,5 +2,5 @@
 
 echo "Running integration tests"
 echo "-------------------------"
-nosetests -v ./test/integration
+nosetests -v ./test/integration --with-coverage --cover-html --cover-package=clarity_ext --cover-erase
 

--- a/validate-unit.sh
+++ b/validate-unit.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 echo "Running unittests"
 echo "-----------------"
-nosetests -v ./test/unit
+nosetests -v ./test/unit --with-coverage --cover-html --cover-package=clarity_ext --cover-erase
 

--- a/validate.sh
+++ b/validate.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
-source ./validate-unit.sh
-source ./validate-integration.sh
 
+echo "Running all tests with coverage"
+echo "-------------------------"
+nosetests -v ./test --with-coverage --cover-html --cover-package=clarity_ext --cover-erase


### PR DESCRIPTION
  - Running the validate scripts now creates coverage files in ./cover
  - Added a test for the lazyprop decorator
  - Fixed some comments
  - Add a script for cleaning up the syntax of all files changed in a
    branch.