### PR TITLE
Lims 655 bugfix

### DIFF
--- a/clarity_ext/domain/common.py
+++ b/clarity_ext/domain/common.py
@@ -1,10 +1,40 @@
+from __builtin__ import isinstance
+
+
 class DomainObjectMixin(object):
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
+            return self._eq_rec(self, other)
         else:
             return False
+
+    def _eq_rec(self, a, b, cache=[]):
+        """
+        Replaces the == operator because of circulating references (e.g. analyte <-> well)
+        Adapted solution taken from
+        http://stackoverflow.com/questions/31415844/using-the-operator-on-circularly-defined-dictionaries
+        """
+        cache = cache + [a, b]
+        if isinstance(a, DomainObjectMixin):
+            a = a.__dict__
+        if isinstance(b, DomainObjectMixin):
+            b = b.__dict__
+        if not isinstance(a, dict) or not isinstance(b, dict):
+            return a == b
+
+        set_keys = set(a.keys())
+        if set_keys != set(b.keys()):
+            return False
+
+        for key in set_keys:
+            if any(a[key] is i for i in cache):
+                continue
+            elif any(b[key] is i for i in cache):
+                continue
+            elif not self._eq_rec(a[key], b[key], cache):
+                return False
+        return True
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/clarity_ext/domain/container.py
+++ b/clarity_ext/domain/container.py
@@ -25,7 +25,11 @@ class Well(DomainObjectMixin):
         return "{}:{}".format(self.position.row, self.position.col)
 
     def __repr__(self):
-        return "{}({}{})".format(self.container.name, self.position.row_letter, self.position.col)
+        if self.container:
+            container_name = self.container.name
+        else:
+            container_name = "<no container>"
+        return "{}({}{})".format(container_name, self.position.row_letter, self.position.col)
 
     @property
     def index_down_first(self):

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -131,6 +131,9 @@ class StepRepository(object):
             if type(obj) == Analyte:
                 original_analyte_from_rest = ApiArtifact(self.session.api, id=obj.id)
                 update_queue.append(obj.updated_rest_resource(original_analyte_from_rest, self.udf_map))
+            elif type(obj) == ResultFile:
+                # TODO: Implement
+                pass
             else:
                 raise Exception("Unknown type {}".format(obj.type))
 

--- a/test/unit/clarity_ext/domain/test_artifact.py
+++ b/test/unit/clarity_ext/domain/test_artifact.py
@@ -1,5 +1,6 @@
 import unittest
 from clarity_ext.domain import Artifact
+from test.unit.clarity_ext.helpers import fake_analyte
 
 
 class TestArtifact(unittest.TestCase):
@@ -17,3 +18,32 @@ class TestArtifact(unittest.TestCase):
     def test_artifact_should_not_equal_non_artifact(self):
         artifact = Artifact()
         self.assertNotEqual(artifact, "string")
+
+    def test_equality_including_mutual_references(self):
+        """
+        Analyte referring to a well, that is referring back to the analyte
+        """
+        def two_identical_analytes():
+            return [
+                fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5", True,
+                              concentration=100, volume=20),
+                fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5", True,
+                              concentration=100, volume=20)
+            ]
+        analytes = two_identical_analytes()
+        self.assertEqual(analytes[0], analytes[1])
+
+    def test_inequality_including_mutual_references(self):
+        """
+        Analyte referring to a well, that is referring back to the analyte
+        """
+        def two_identical_analytes():
+            return [
+                fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5", True,
+                              concentration=100, volume=20),
+                fake_analyte("cont-id1", "art-id2", "sample1", "art-name2", "D:6", True,
+                              concentration=100, volume=20)
+            ]
+        analytes = two_identical_analytes()
+        self.assertNotEqual(analytes[0], analytes[1])
+

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -26,6 +26,7 @@ def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_na
     analyte.id = artifact_id
     analyte.is_input = is_input
     analyte.generation_type = Artifact.PER_INPUT
+    well.artifact = analyte
     return analyte
 
 


### PR DESCRIPTION
Fix so that all integration tests work:
* Adapt _repr_ of well to handle if the container is not set. 
* Do not cast exception for ResultFile in update_objects in step_repository. Replace with TODO
Prevent an infinite loop when comparing equality for objects containing mutual references, e.g. Analyte --> well and Well --> artifact. 