### PR TITLE
Response from scripts at integrations tests

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -39,6 +39,7 @@ class ExtensionContext(object):
         self.current_step = session.current_step
         self.artifact_service = artifact_service
         self.file_service = file_service
+        self.response = None
 
     @staticmethod
     def create(step_id, cache=False):
@@ -129,6 +130,6 @@ class ExtensionContext(object):
 
     def commit(self):
         """Commits all objects that have been added via the update method, using batch processing if possible"""
-        self.artifact_service.update_artifacts(self._update_queue)
+        self.response = self.artifact_service.update_artifacts(self._update_queue)
 
 

--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -130,6 +130,6 @@ class ExtensionContext(object):
 
     def commit(self):
         """Commits all objects that have been added via the update method, using batch processing if possible"""
-        self.response = self.artifact_service.update_artifacts(self._update_queue)
+        return self.artifact_service.update_artifacts(self._update_queue)
 
 

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -110,6 +110,7 @@ class DilutionScheme(object):
         Calculates all derived values needed in dilute driver file.
         """
         pairs = artifact_service.all_analyte_pairs()
+
         self.current_step_id = artifact_service.step_repository.session.current_step_id
 
         # TODO: Is it safe to just check for the container for the first output

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -1,6 +1,6 @@
 from clarity_ext.domain.container import ContainerPosition, Well
 from clarity_ext.utils import get_and_apply
-from clarity_ext.domain.common import DomainObjectMixin
+from clarity_ext.domain.common import DomainObjectMixin, AssignLogger
 from clarity_ext.domain.artifact import Artifact
 
 
@@ -28,7 +28,7 @@ class Analyte(Artifact):
         self.target_volume = get_and_apply(kwargs, "target_volume", None, float)
 
     def __repr__(self):
-        return "{} ({})".format(self.name, self.sample.id)
+        return "{} ({})".format(self.name, self.id)
 
     @staticmethod
     def create_from_rest_resource(resource, udf_map, container_repo):
@@ -52,7 +52,7 @@ class Analyte(Artifact):
         well.artifact = analyte
         return analyte
 
-    def updated_rest_resource(self, original_rest_resource, udf_map):
+    def updated_rest_resource(self, original_rest_resource, udf_map, updated_fields):
         """
         :param original_rest_resource: The rest resource in the state as in the api cache
         :param udf_map: global udf map for all entities
@@ -66,17 +66,20 @@ class Analyte(Artifact):
 
         # Update udf values
         analyte_udf_map = udf_map['Analyte']
-        values_by_udf_names = {analyte_udf_map[key]: self.__dict__[key] for key in analyte_udf_map}
+        values_by_udf_names = {analyte_udf_map[key]: self.__dict__[key]
+                               for key in analyte_udf_map if key in updated_fields}
+        assigner = AssignLogger(self)
         # Retrieve fields that are updated, only these field should be included in the rest update
         for key in values_by_udf_names:
             if _updated_rest_resource.udf.get(key, None):
                 original_type = type(_updated_rest_resource.udf[key])
                 value = get_and_apply(values_by_udf_names, key, None, original_type)
-                _updated_rest_resource.udf[key] = value
+                _updated_rest_resource.udf[key] = assigner.log_assign(key, value)
 
         # Update other fields
-        _updated_rest_resource.name = self.name
-        return _updated_rest_resource
+        if 'name' in updated_fields:
+            _updated_rest_resource.name = assigner.log_assign('name', self.name)
+        return _updated_rest_resource, assigner.log
 
 
 class Sample(DomainObjectMixin):

--- a/clarity_ext/domain/artifact.py
+++ b/clarity_ext/domain/artifact.py
@@ -27,3 +27,6 @@ class ArtifactPair(DomainObjectMixin):
         self.input_artifact = input_artifact
         self.output_artifact = output_artifact
 
+    def __repr__(self):
+        return "{}, {}".format(self.input_artifact.id, self.output_artifact.id)
+

--- a/clarity_ext/domain/common.py
+++ b/clarity_ext/domain/common.py
@@ -38,3 +38,25 @@ class DomainObjectMixin(object):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+
+    def differing_fields(self, other):
+        if isinstance(other, self.__class__):
+            ret = []
+            for key in self.__dict__:
+                if self.__dict__[key] != other.__dict__[key]:
+                    ret.append(key)
+            return ret
+        else:
+            return None
+
+
+class AssignLogger:
+    def __init__(self, domain_object_mixin):
+        self.log = []
+        self.domain_object_mixin = domain_object_mixin
+
+    def log_assign(self, field_name, value):
+        class_name = self.domain_object_mixin.__class__
+        lims_id = self.domain_object_mixin.id
+        self.log.append((class_name, lims_id, field_name, value))
+        return value

--- a/clarity_ext/domain/common.py
+++ b/clarity_ext/domain/common.py
@@ -56,7 +56,7 @@ class AssignLogger:
         self.domain_object_mixin = domain_object_mixin
 
     def log_assign(self, field_name, value):
-        class_name = self.domain_object_mixin.__class__
+        class_name = self.domain_object_mixin.__class__.__name__
         lims_id = self.domain_object_mixin.id
-        self.log.append((class_name, lims_id, field_name, value))
+        self.log.append((class_name, lims_id, field_name, str(value)))
         return value

--- a/clarity_ext/domain/container.py
+++ b/clarity_ext/domain/container.py
@@ -28,7 +28,7 @@ class Well(DomainObjectMixin):
         if self.container:
             container_name = self.container.name
         else:
-            container_name = "<no container>"
+            container_name = '<no container>'
         return "{}({}{})".format(container_name, self.position.row_letter, self.position.col)
 
     @property

--- a/clarity_ext/driverfile.py
+++ b/clarity_ext/driverfile.py
@@ -53,6 +53,7 @@ class GeneralFileService(object):
             os.mkdir(upload_path)
             # The LIMS does always add a prefix with the artifact ID:
             new_file_name = self.specific_file_service.lims_adapted_file_name()
+            print("driverfile, new_file_name: {}".format(new_file_name))
             new_file_path = os.path.join(upload_path, new_file_name)
             shutil.copyfile(local_file, new_file_path)
 
@@ -61,6 +62,9 @@ class GeneralFileService(object):
             with open(local_file, 'r') as f:
                 print f.read()
             print "---"
+
+    def file_key(self, file_name):
+        return self.specific_file_service.file_key(file_name)
 
 
 class DriverFileService:
@@ -92,6 +96,13 @@ class DriverFileService:
     def content(self):
         return self.extension.content()
 
+    def file_key(self, file_name):
+        match = re.match(r"(^92-\d+).*$", file_name)
+        if match:
+            return match.group(1)
+        else:
+            return None
+
     @lazyprop
     def artifact(self):
         artifacts = [shared_file for shared_file in self.extension.context.shared_files
@@ -114,12 +125,19 @@ class ResponseFileService:
         return "--- {}".format(self.local_file)
 
     def lims_adapted_file_name(self):
-        return self.local_file
+        return "{}_{}".format(self.extension.context.session.current_step_id, os.path.basename(self.local_file))
 
     def content(self):
         self.extension.execute()
         for row in self.extension.response:
             yield "\t".join(row)
+
+    def file_key(self, file_name):
+        match = re.match(r"(^24-\d+).*$", file_name)
+        if match:
+            return match.group(1)
+        else:
+            return None
 
     def print_log(self):
         pass

--- a/clarity_ext/extensions.py
+++ b/clarity_ext/extensions.py
@@ -265,32 +265,33 @@ class GeneralExtension(object):
         """
         self.context = context
         self.logger = logging.getLogger(self.__class__.__module__)
+        self.response = None
+
+    @abstractmethod
+    def integration_tests(self):
+        """Returns `DriverFileTest`s that should be run to validate the code"""
+        pass
 
     def test(self, pid):
         """Creates a test instance suitable for this extension"""
         return ExtensionTest(pid=pid)
 
 
-class DriverFileExtension(GeneralExtension):
+class GeneralFileExtension(GeneralExtension):
     __metaclass__ = ABCMeta
 
     def newline(self):
         return "\n"
 
     @abstractmethod
-    def content(self):
-        """Yields the output lines of the file"""
-        pass
-
-    @abstractmethod
     def filename(self):
-        """Returns the name of the file"""
+        """Returns the name of the file
+        (containing either response from update, or a file to be uploaded to lims)"""
         pass
 
-    @abstractmethod
-    def integration_tests(self):
-        """Returns `DriverFileTest`s that should be run to validate the code"""
-        pass
+
+class DriverFileExtension(GeneralFileExtension):
+    __metaclass__ = ABCMeta
 
     @abstractmethod
     def shared_file(self):
@@ -305,6 +306,10 @@ class DriverFileExtension(GeneralExtension):
         if len(results) > 0:
             raise ValueError("Validation errors: ".format(os.path.sep.join(report)))
 
+    @abstractmethod
+    def content(self):
+        """Yields the output lines of the file, or the response at updates"""
+        pass
 
 class ExtensionTest(object):
     def __init__(self, pid):

--- a/clarity_ext/extensions.py
+++ b/clarity_ext/extensions.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import importlib
 import os
 import shutil
-from clarity_ext.driverfile import DriverFileService
+from clarity_ext.driverfile import GeneralFileService, DriverFileService, ResponseFileService
 from context import ExtensionContext
 import clarity_ext.utils as utils
 from abc import ABCMeta, abstractmethod
@@ -150,9 +150,15 @@ class ExtensionService(object):
 
                 if issubclass(extension, DriverFileExtension):
                     instance = extension(context)
-                    driver_file_svc = DriverFileService(instance, ".")
+                    driver_file_svc = DriverFileService(instance, self.logger)
+                    file_svc = GeneralFileService(driver_file_svc, ".")
                     commit = mode == self.RUN_MODE_EXEC
-                    driver_file_svc.execute(commit=commit, artifacts_to_stdout=artifacts_to_stdout)
+                    file_svc.execute(commit=commit, artifacts_to_stdout=artifacts_to_stdout)
+                elif issubclass(extension, GeneralFileExtension):
+                    instance = extension(context)
+                    response_file_svc = ResponseFileService(instance, self.logger)
+                    file_svc = GeneralFileService(response_file_svc, ".")
+                    file_svc.execute(commit=False, artifacts_to_stdout=artifacts_to_stdout)
                 elif issubclass(extension, GeneralExtension):
                     # TODO: Generating the instance twice (for metadata above)
                     instance = extension(context)

--- a/clarity_ext/extensions.py
+++ b/clarity_ext/extensions.py
@@ -147,7 +147,7 @@ class ExtensionService(object):
                 cache_artifacts = mode == self.RUN_MODE_TEST
                 context = ExtensionContext.create(
                     run_arguments["pid"], cache=cache_artifacts)
-
+                file_svc = None
                 if issubclass(extension, DriverFileExtension):
                     instance = extension(context)
                     driver_file_svc = DriverFileService(instance, self.logger)
@@ -169,9 +169,9 @@ class ExtensionService(object):
 
                 os.chdir(old_dir)
 
-                if os.path.exists(frozen_path):
-                    test_info = RunDirectoryInfo(path)
-                    frozen_info = RunDirectoryInfo(frozen_path)
+                if os.path.exists(frozen_path) and file_svc:
+                    test_info = RunDirectoryInfo(path, file_svc)
+                    frozen_info = RunDirectoryInfo(frozen_path, file_svc)
                     diff_report = list(test_info.compare(frozen_info))
                     if len(diff_report) > 0:
                         msg = []
@@ -209,9 +209,10 @@ class RunDirectoryInfo(object):
 
     Used to compare two different runs, e.g. a current test and a frozen test
     """
-    def __init__(self, path):
+    def __init__(self, path, file_service):
         self.path = path
         self.uploaded_path = os.path.join(self.path, "uploaded")
+        self.file_service = file_service
 
     @lazyprop
     def uploaded_files(self):
@@ -221,12 +222,11 @@ class RunDirectoryInfo(object):
             return ret
         for file_name in os.listdir(self.uploaded_path):
             assert os.path.isfile(os.path.join(self.uploaded_path, file_name))
-            match = re.match(r"(^92-\d+).*$", file_name)
-            if match:
-                key = match.group(1)
-                if key in ret:
+            file_key = self.file_service.file_key(file_name)
+            if file_key:
+                if file_key in ret:
                     raise Exception("More than one file with the same prefix")
-                ret[key] = os.path.abspath(os.path.join(self.uploaded_path, file_name))
+                ret[file_key] = os.path.abspath(os.path.join(self.uploaded_path, file_name))
             else:
                 raise Exception("Unexpected file name {}, should start with Clarity ID".format(file_name))
         return ret

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -2,6 +2,7 @@ from clarity_ext.domain.artifact import Artifact
 from clarity_ext.domain.analyte import Analyte
 from clarity_ext.domain.result_file import ResultFile
 from clarity_ext.repository.container_repository import ContainerRepository
+from clarity_ext.utils import flatten
 from genologics.entities import Artifact as ApiArtifact
 import copy
 
@@ -150,7 +151,7 @@ class StepRepository(object):
                 update_queue.append(api_resources)
 
         self.session.api.put_batch(update_queue)
-        return response
+        return flatten(response)
 
     def _retrieve_updated_fields(self, updated_artifact):
         orig_art = self.orig_state_cache[updated_artifact.id]

--- a/clarity_ext/service/artifact_service.py
+++ b/clarity_ext/service/artifact_service.py
@@ -93,5 +93,5 @@ class ArtifactService:
         return ret
 
     def update_artifacts(self, update_queue):
-        self.step_repository.update_artifacts(update_queue)
-
+        response = self.step_repository.update_artifacts(update_queue)
+        return response

--- a/clarity_ext/utils.py
+++ b/clarity_ext/utils.py
@@ -91,3 +91,7 @@ def unique(items, fn):
         if key not in seen:
             seen.add(key)
             yield item
+
+
+def flatten(list_of_lists):
+    return [item for sublist in list_of_lists for item in sublist]

--- a/test/unit/clarity_ext/dilution/test_update_fields.py
+++ b/test/unit/clarity_ext/dilution/test_update_fields.py
@@ -40,4 +40,3 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
             source_volume_sum += outcome
         expected_sum = 96.0
         self.assertEqual(expected_sum, source_volume_sum)
-


### PR DESCRIPTION
Make possible to generate response for scripts that are updating fields in LIMS. 
Response generation:
* Use a cache with the original states of artifacts. Compare updated artifacts with this cache to extract a list of updated fields and their values.
* Export the response to a file named response.txt, in the same manner as in driver file generation (same code is used)
* It's possible to freeze the response to be used in integration tests, (same way as for driver files)