### PR TITLE
Lims 683 set udf2

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -130,6 +130,6 @@ class ExtensionContext(object):
 
     def commit(self):
         """Commits all objects that have been added via the update method, using batch processing if possible"""
-        return self.artifact_service.update_artifacts(self._update_queue)
+        self.response = self.artifact_service.update_artifacts(self._update_queue)
 
 

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -1,6 +1,6 @@
 from clarity_ext.domain.container import ContainerPosition, Well
 from clarity_ext.utils import get_and_apply
-from clarity_ext.domain.common import DomainObjectMixin, AssignLogger
+from clarity_ext.domain.common import DomainObjectMixin
 from clarity_ext.domain.artifact import Artifact
 
 
@@ -12,11 +12,12 @@ class Analyte(Artifact):
     in udf_map, so they can be overridden in different installations.
     """
 
-    def __init__(self, name=None, well=None, sample=None, id=None, **kwargs):
+    def __init__(self, api_resource, name=None, well=None, sample=None,
+                 artifact_specific_udf_map=None, id=None, **kwargs):
         """
         Creates an analyte
         """
-        super(self.__class__, self).__init__()
+        super(self.__class__, self).__init__(api_resource, artifact_specific_udf_map)
         self.name = name
         self.well = well
         self.container = well.container
@@ -47,7 +48,7 @@ class Analyte(Artifact):
         pos = ContainerPosition.create(resource.location[1])
         well = Well(pos, container)
         sample = Sample.create_from_rest_resource(resource.samples[0])
-        analyte = Analyte(resource.name, well, sample, resource.id, **kwargs)
+        analyte = Analyte(resource, resource.name, well, sample, analyte_udf_map, resource.id, **kwargs)
         analyte.api_resource = resource
         well.artifact = analyte
         return analyte
@@ -68,18 +69,17 @@ class Analyte(Artifact):
         analyte_udf_map = udf_map['Analyte']
         values_by_udf_names = {analyte_udf_map[key]: self.__dict__[key]
                                for key in analyte_udf_map if key in updated_fields}
-        assigner = AssignLogger(self)
         # Retrieve fields that are updated, only these field should be included in the rest update
         for key in values_by_udf_names:
             if _updated_rest_resource.udf.get(key, None):
                 original_type = type(_updated_rest_resource.udf[key])
                 value = get_and_apply(values_by_udf_names, key, None, original_type)
-                _updated_rest_resource.udf[key] = assigner.log_assign(key, value)
+                _updated_rest_resource.udf[key] = self.assigner.log_assign(key, value)
 
         # Update other fields
         if 'name' in updated_fields:
-            _updated_rest_resource.name = assigner.log_assign('name', self.name)
-        return _updated_rest_resource, assigner.log
+            _updated_rest_resource.name = self.assigner.log_assign('name', self.name)
+        return _updated_rest_resource, self.assigner.consume()
 
 
 class Sample(DomainObjectMixin):

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -74,11 +74,11 @@ class Analyte(Artifact):
             if _updated_rest_resource.udf.get(key, None):
                 original_type = type(_updated_rest_resource.udf[key])
                 value = get_and_apply(values_by_udf_names, key, None, original_type)
-                _updated_rest_resource.udf[key] = self.assigner.log_assign(key, value)
+                _updated_rest_resource.udf[key] = self.assigner.register_assign(key, value)
 
         # Update other fields
         if 'name' in updated_fields:
-            _updated_rest_resource.name = self.assigner.log_assign('name', self.name)
+            _updated_rest_resource.name = self.assigner.register_assign('name', self.name)
         return _updated_rest_resource, self.assigner.consume()
 
 

--- a/clarity_ext/domain/artifact.py
+++ b/clarity_ext/domain/artifact.py
@@ -1,4 +1,6 @@
 from clarity_ext.domain.common import DomainObjectMixin
+from clarity_ext.utils import lazyprop
+from clarity_ext.domain.common import AssignLogger
 
 
 class Artifact(DomainObjectMixin):
@@ -13,9 +15,38 @@ class Artifact(DomainObjectMixin):
     OUTPUT_TYPE_ANALYTE = 2
     OUTPUT_TYPE_SHARED_RESULT_FILE = 3
 
-    def __init__(self):
+    def __init__(self, api_resource=None, artifact_specific_udf_map=dict()):
         self.is_input = None  # Set to true if this is an input artifact
         self.generation_type = None  # Set to PER_INPUT or PER_ALL_INPUTS if applicable
+        self.udf_map = artifact_specific_udf_map
+        self.assigner = AssignLogger(self)
+        self.api_resource = api_resource
+
+    @lazyprop
+    def udf_backward_map(self):
+        return {self.udf_map[key]: key for key in self.udf_map}
+
+    def reset_assigner(self):
+        self.assigner = AssignLogger(self)
+
+    def set_udf(self, name, value, from_unit=None, to_unit=None):
+        if from_unit:
+            value = self.units.convert(value, from_unit, to_unit)
+        if name in self.udf_backward_map:
+            # Assign existing instance variable
+            # Log for assignment of instance variables are handled in
+            # step_repository.commit()
+            self.__dict__[self.udf_backward_map[name]] = value
+        else:
+            # There is no mapped instance variable for this udf.
+            # Log the assignment right away
+            self.api_resource.udf[name] = self.assigner.log_assign(name, value)
+
+    def get_udf(self, name):
+        return self.api_resource.udf[name]
+
+    def commit(self):
+        self.api_resource.put()
 
 
 class ArtifactPair(DomainObjectMixin):

--- a/clarity_ext/domain/artifact.py
+++ b/clarity_ext/domain/artifact.py
@@ -40,7 +40,7 @@ class Artifact(DomainObjectMixin):
         else:
             # There is no mapped instance variable for this udf.
             # Log the assignment right away
-            self.api_resource.udf[name] = self.assigner.log_assign(name, value)
+            self.api_resource.udf[name] = self.assigner.register_assign(name, value)
 
     def get_udf(self, name):
         return self.api_resource.udf[name]

--- a/clarity_ext/domain/common.py
+++ b/clarity_ext/domain/common.py
@@ -1,4 +1,5 @@
 from __builtin__ import isinstance
+import copy
 
 
 class DomainObjectMixin(object):
@@ -43,14 +44,14 @@ class DomainObjectMixin(object):
         if isinstance(other, self.__class__):
             ret = []
             for key in self.__dict__:
-                if self.__dict__[key] != other.__dict__[key]:
+                if self.__dict__.get(key, None) != other.__dict__.get(key, None):
                     ret.append(key)
             return ret
         else:
             return None
 
 
-class AssignLogger:
+class AssignLogger(DomainObjectMixin):
     def __init__(self, domain_object_mixin):
         self.log = []
         self.domain_object_mixin = domain_object_mixin
@@ -60,3 +61,8 @@ class AssignLogger:
         lims_id = self.domain_object_mixin.id
         self.log.append((class_name, lims_id, field_name, str(value)))
         return value
+
+    def consume(self):
+        log_output = copy.copy(self.log)
+        self.log = []
+        return log_output

--- a/clarity_ext/domain/common.py
+++ b/clarity_ext/domain/common.py
@@ -56,7 +56,7 @@ class AssignLogger(DomainObjectMixin):
         self.log = []
         self.domain_object_mixin = domain_object_mixin
 
-    def log_assign(self, field_name, value):
+    def register_assign(self, field_name, value):
         class_name = self.domain_object_mixin.__class__.__name__
         lims_id = self.domain_object_mixin.id
         self.log.append((class_name, lims_id, field_name, str(value)))

--- a/clarity_ext/domain/result_file.py
+++ b/clarity_ext/domain/result_file.py
@@ -5,31 +5,21 @@ from clarity_ext.domain.artifact import Artifact
 class ResultFile(Artifact):
     """Encapsulates a ResultFile in Clarity"""
 
-    def __init__(self, api_resource, units, id=None):
-        super(self.__class__, self).__init__()
-        self.api_resource = api_resource
+    def __init__(self, api_resource, units, artifact_specific_udf_map, id=None):
+        super(self.__class__, self).__init__(api_resource, artifact_specific_udf_map)
         self.units = units
         self.id = id
 
-    def commit(self):
-        self.api_resource.put()
-
-    def set_udf(self, name, value, from_unit=None, to_unit=None):
-        if from_unit:
-            value = self.units.convert(value, from_unit, to_unit)
-        self.api_resource.udf[name] = value
-
-    def get_udf(self, name):
-        return self.api_resource.udf[name]
-
     @staticmethod
-    def create_from_rest_resource(resource, container_repo):
+    def create_from_rest_resource(resource, udf_map, container_repo):
         """
         Creates a `ResultFile` from the REST resource object.
         The container is fetched from the container_repo.
         """
+
+        result_file_udf_map = udf_map.get('ResultFile', None)
         ret = ResultFile(api_resource=resource,
-                         units=UnitConversion(), id=resource.id)
+                         units=UnitConversion(), artifact_specific_udf_map=result_file_udf_map, id=resource.id)
 
         try:
             container_resource = resource.location[0]

--- a/clarity_ext/driverfile.py
+++ b/clarity_ext/driverfile.py
@@ -129,7 +129,7 @@ class ResponseFileService:
 
     def content(self):
         self.extension.execute()
-        for row in self.extension.response:
+        for row in self.extension.context.response:
             yield "\t".join(row)
 
     def file_key(self, file_name):

--- a/clarity_ext/utils.py
+++ b/clarity_ext/utils.py
@@ -91,7 +91,3 @@ def unique(items, fn):
         if key not in seen:
             seen.add(key)
             yield item
-
-
-def flatten(list_of_lists):
-    return [item for sublist in list_of_lists for item in sublist]

--- a/test/unit/clarity_ext/domain/test_artifact.py
+++ b/test/unit/clarity_ext/domain/test_artifact.py
@@ -47,3 +47,6 @@ class TestArtifact(unittest.TestCase):
         analytes = two_identical_analytes()
         self.assertNotEqual(analytes[0], analytes[1])
 
+    def test_backward_udf_map_empty_if_no_udf_map(self):
+        artifact = Artifact()
+        self.assertEqual(artifact.udf_backward_map, dict())

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -22,7 +22,8 @@ def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_na
     pos = ContainerPosition.create(well_key)
     well = Well(pos, container)
     sample = Sample(sample_id)
-    analyte = Analyte(analyte_name, well, sample, **kwargs)
+    api_resource = None
+    analyte = Analyte(api_resource, analyte_name, well, sample, **kwargs)
     analyte.id = artifact_id
     analyte.is_input = is_input
     analyte.generation_type = Artifact.PER_INPUT


### PR DESCRIPTION
Update to db reflects the state of the domain object. It's also possible to update udf that is not represented as an instance variable in the corresponding domain object. The function set_udf updates instance variable if it exists, otherwise, updates the api resource. When committing, all changes in instance variables are transferred to the api resources.