### PR TITLE
Integration test fixes

### DIFF
--- a/clarity_ext/driverfile.py
+++ b/clarity_ext/driverfile.py
@@ -95,11 +95,12 @@ class GeneralFileService(object):
 
 
 class DriverFileService:
-    def __init__(self, extension, os_service, logger=None):
+    def __init__(self, extension, shared_file_name, os_service, logger=None):
         self.extension = extension
         self.logger = logger
         self.local_file = None
         self.os_service = os_service
+        self.shared_file_name = shared_file_name
 
     def commit(self):
         # Find the output on the current step
@@ -134,13 +135,13 @@ class DriverFileService:
     @lazyprop
     def artifact(self):
         artifacts = [shared_file for shared_file in self.extension.context.shared_files
-                     if shared_file.name == self.extension.shared_file()]
+                     if shared_file.name == self.shared_file_name]
         assert len(artifacts) == 1
         return artifacts[0]
 
     @staticmethod
-    def create_file_service(instance, logger, os_service):
-        driver_file_service = DriverFileService(instance, os_service, logger)
+    def create_file_service(instance, shared_file_name, logger, os_service):
+        driver_file_service = DriverFileService(instance, shared_file_name, os_service, logger)
         return GeneralFileService(driver_file_service, ".", os_service)
 
 

--- a/clarity_ext/extensions.py
+++ b/clarity_ext/extensions.py
@@ -2,18 +2,19 @@ from __future__ import print_function
 import importlib
 import os
 import shutil
-from clarity_ext.driverfile import GeneralFileService, DriverFileService, ResponseFileService
+from clarity_ext.driverfile import DriverFileService, ResponseFileService
 from clarity_ext.driverfile import OSService
 from context import ExtensionContext
 import clarity_ext.utils as utils
 from abc import ABCMeta, abstractmethod
 import logging
 import difflib
-import re
 from clarity_ext.utils import lazyprop
 from clarity_ext import ClaritySession
 from clarity_ext.repository import StepRepository
 from clarity_ext.service import ArtifactService
+from test.integration.integration_test_service import IntegrationTest
+from clarity_ext.repository.step_repository import DEFAULT_UDF_MAP
 
 
 # Defines all classes that are expected to be extended. These are
@@ -49,6 +50,8 @@ class ExtensionService(object):
             raise ValueError("Unexpected mode")
 
     def _parse_run_argument(self, in_argument):
+        if isinstance(in_argument, IntegrationTest):
+            return in_argument.run_argument_dict
         if isinstance(in_argument, str):
             return {"pid": in_argument}
         elif isinstance(in_argument, dict):
@@ -67,6 +70,11 @@ class ExtensionService(object):
             return run_arguments["shared_file"]
         else:
             return extension.shared_file()
+
+    def _artifact_service(self, pid):
+        session = ClaritySession.create(pid)
+        step_repo = StepRepository(session, DEFAULT_UDF_MAP)
+        return ArtifactService(step_repo)
 
     def execute(self, module, mode, run_arguments_list=None, config=None, artifacts_to_stdout=True,
                 print_help=True, use_cache=None):
@@ -107,6 +115,11 @@ class ExtensionService(object):
         instance = extension(None)
 
         if not run_arguments_list and (mode == self.RUN_MODE_TEST or mode == self.RUN_MODE_FREEZE):
+            for integration_test in instance.integration_tests():
+                if isinstance(integration_test, IntegrationTest) and integration_test.preparer:
+                    artifact_service = self._artifact_service(integration_test.pid())
+                    integration_test.preparer.prepare(artifact_service)
+
             run_arguments_list = map(self._parse_run_argument, instance.integration_tests())
             if len(run_arguments_list) == 0:
                 print("WARNING: No integration tests defined. Not able to test.")

--- a/test/integration/integration_test_service.py
+++ b/test/integration/integration_test_service.py
@@ -10,16 +10,15 @@ class IntegrationTest:
             self.run_argument_dict.update(run_argument_dict)
 
         if update_matrix:
-            self.preparer = IntegrationTestPrepare(update_matrix, self.pid)
+            self.preparer = IntegrationTestPrepare(update_matrix)
 
     def pid(self):
         return self.run_argument_dict["pid"]
 
 
 class IntegrationTestPrepare:
-    def __init__(self, update_matrix, pid):
+    def __init__(self, update_matrix):
         self.update_matrix = update_matrix
-        self.pid = pid
 
     def prepare(self, artifact_service):
         input_artifacts = artifact_service.all_input_artifacts()

--- a/test/integration/integration_test_service.py
+++ b/test/integration/integration_test_service.py
@@ -1,0 +1,50 @@
+"""Help classes to manage integration tests"""
+
+
+class IntegrationTest:
+    def __init__(self, pid=None, run_argument_dict=None, update_matrix=None):
+        self.run_argument_dict = {}
+        if pid:
+            self.run_argument_dict = {"pid": pid}
+        if run_argument_dict:
+            self.run_argument_dict.update(run_argument_dict)
+
+        if update_matrix:
+            self.preparer = IntegrationTestPrepare(update_matrix, self.pid)
+
+    def pid(self):
+        return self.run_argument_dict["pid"]
+
+
+class IntegrationTestPrepare:
+    def __init__(self, update_matrix, pid):
+        self.update_matrix = update_matrix
+        self.pid = pid
+
+    def prepare(self, artifact_service):
+        input_artifacts = artifact_service.all_input_artifacts()
+        artifact_dict = {artifact.id: artifact for artifact in input_artifacts}
+        self._check_artifacts_exists(artifact_dict)
+        update_queue = []
+        for update_row in self.update_matrix:
+            art_id = update_row[0]
+            udf_name = update_row[1]
+            value = update_row[2]
+            artifact = artifact_dict[art_id]
+            artifact.set_udf(udf_name, value)
+            update_queue.append(artifact)
+
+        artifact_service.update_artifacts(update_queue)
+
+    def _check_artifacts_exists(self, artifact_dict):
+        for update_row in self.update_matrix:
+            art_id = update_row[0]
+            if art_id not in artifact_dict:
+                raise ArtifactsNotFound("Given lims-id is not matching artifacts in step ({})".format(art_id))
+
+
+class ArtifactsNotFound(Exception):
+    pass
+
+
+

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -1,6 +1,7 @@
 from clarity_ext.domain import Container, Analyte, Well, ContainerPosition, Sample, Artifact
 from mock import MagicMock
 from clarity_ext.service import ArtifactService, FileService
+from clarity_ext.repository.step_repository import DEFAULT_UDF_MAP
 
 
 def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_name=None,
@@ -23,7 +24,9 @@ def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_na
     well = Well(pos, container)
     sample = Sample(sample_id)
     api_resource = None
-    analyte = Analyte(api_resource, analyte_name, well, sample, **kwargs)
+    udf_map = DEFAULT_UDF_MAP['Analyte']
+    analyte = Analyte(api_resource=api_resource, name=analyte_name, well=well,
+                      sample=sample, artifact_specific_udf_map=udf_map, **kwargs)
     analyte.id = artifact_id
     analyte.is_input = is_input
     analyte.generation_type = Artifact.PER_INPUT

--- a/test/unit/clarity_ext/service/test_file_service.py
+++ b/test/unit/clarity_ext/service/test_file_service.py
@@ -14,7 +14,7 @@ class TestGeneralFileService(unittest.TestCase):
         extension = fake_extension("file1.txt", context)
         os_service = MagicMock()
         logger = logging.getLogger(__name__)
-        file_svc = DriverFileService.create_file_service(extension, logger, os_service)
+        file_svc = DriverFileService.create_file_service(extension, extension.shared_file(), logger, os_service)
         file_svc.execute()
         os_service.copy_file.assert_called_with(".{sep}file1.txt".format(sep=os.sep),
                                                 ".{sep}uploaded{sep}art1_file1.txt".format(sep=os.sep))

--- a/test/unit/clarity_ext/utility/test_integration_test_service.py
+++ b/test/unit/clarity_ext/utility/test_integration_test_service.py
@@ -1,0 +1,45 @@
+import unittest
+from test.integration.integration_test_service import IntegrationTest
+from mock import MagicMock
+from mock import Mock
+from test.unit.clarity_ext import helpers
+from test.unit.clarity_ext.helpers import fake_analyte
+from clarity_ext.domain import Analyte, Artifact
+
+
+class TestIntegrationTestService(unittest.TestCase):
+
+    def test_returning_pid(self):
+        test = IntegrationTest(pid="pid1")
+        self.assertEqual(test.pid(), "pid1")
+
+        run_args = {"pid": "pid1"}
+        test = IntegrationTest(run_argument_dict=run_args)
+        self.assertEqual(test.pid(), "pid1")
+
+    def test_run_prepare(self):
+        artifact_set = [(fake_analyte("cont1", "art1", "sample1", "art1", "A:1", True, volume=1),
+                         fake_analyte("cont1", "art2", "sample1", "art2", "A:1", False)),
+                        (fake_analyte("cont1", "art3", "sample2", "art3", "B:1", True, volume=0),
+                         fake_analyte("cont1", "art4", "sample2", "art4", "B:1", False))]
+
+        def pre_test_artifact_set():
+            return artifact_set
+
+        update_matrix = [("art1", "Current sample volume (ul)", 50),
+                         ("art3", "Current sample volume (ul)", 50)]
+
+        artifact_service = helpers.mock_artifact_service(pre_test_artifact_set)
+        test = IntegrationTest(pid="pid1", update_matrix=update_matrix)
+        self.assertIsNotNone(test.preparer)
+
+        artifact_service.update_artifacts = Mock()
+        test.preparer.prepare(artifact_service)
+
+        art1 = pre_test_artifact_set()[0][0]
+        art3 = pre_test_artifact_set()[1][0]
+        expected_updated_queue = [art1, art3]
+
+        artifact_service.update_artifacts.assert_called_with(expected_updated_queue)
+        self.assertEqual(art1.volume, 50)
+        self.assertEqual(art3.volume, 50)


### PR DESCRIPTION
Fix #1:
Fix shared file names for integration tests. Function shared_file in extension is to be used in production and be able to generate a file name based on current date and user initials, whereas integration tests use a shared file name already created and should therefore be hardcoded. 

Fix #2:
Possibility for preparation of integration tests. Source volume in dilutions are updated in a relative basis (current volume - dilute volume) and are therefor changing for each integration test run. Here is a class for running preparation code before the integration test is run. In this case, the volumes are updated to predefined values. 