### PR TITLE
Lims 703 unit conversion bugfix

### DIFF
--- a/clarity_ext/domain/artifact.py
+++ b/clarity_ext/domain/artifact.py
@@ -1,7 +1,7 @@
 from clarity_ext.domain.common import DomainObjectMixin
 from clarity_ext.utils import lazyprop
 from clarity_ext.domain.common import AssignLogger
-from clarity_ext.utils import get_and_apply
+from clarity_ext.unit_conversion import UnitConversion
 
 
 class Artifact(DomainObjectMixin):
@@ -35,7 +35,8 @@ class Artifact(DomainObjectMixin):
 
     def set_udf(self, name, value, from_unit=None, to_unit=None):
         if from_unit:
-            value = self.units.convert(value, from_unit, to_unit)
+            units = UnitConversion()
+            value = units.convert(value, from_unit, to_unit)
         if name in self.udf_backward_map:
             # Assign existing instance variable
             # Log for assignment of instance variables are handled in
@@ -54,11 +55,7 @@ class Artifact(DomainObjectMixin):
         :param original_rest_resource: The rest resource in the state as in the api cache
         :return: An updated rest resource according to changes in this instance of Analyte
         """
-        # TODO: Update udfs that is not present in the original xml received from db
-        # A ticket is sent to Clarity support (160902)
         _updated_rest_resource = original_rest_resource
-        # TODO: This implementation is not ready! Implementation is moved to another ticket
-        # in Jira
 
         # Update udf values
         values_by_udf_names = {self.udf_map[key]: self.__dict__[key]

--- a/clarity_ext/domain/result_file.py
+++ b/clarity_ext/domain/result_file.py
@@ -5,9 +5,8 @@ from clarity_ext.domain.artifact import Artifact
 class ResultFile(Artifact):
     """Encapsulates a ResultFile in Clarity"""
 
-    def __init__(self, api_resource, units, artifact_specific_udf_map, id=None):
+    def __init__(self, api_resource, artifact_specific_udf_map, id=None):
         super(self.__class__, self).__init__(api_resource, artifact_specific_udf_map)
-        self.units = units
         self.id = id
 
     @staticmethod
@@ -19,7 +18,7 @@ class ResultFile(Artifact):
 
         result_file_udf_map = udf_map.get('ResultFile', None)
         ret = ResultFile(api_resource=resource,
-                         units=UnitConversion(), artifact_specific_udf_map=result_file_udf_map, id=resource.id)
+                         artifact_specific_udf_map=result_file_udf_map, id=resource.id)
 
         try:
             container_resource = resource.location[0]

--- a/test/unit/clarity_ext/domain/test_artifact.py
+++ b/test/unit/clarity_ext/domain/test_artifact.py
@@ -1,6 +1,8 @@
 import unittest
 from clarity_ext.domain import Artifact
 from test.unit.clarity_ext.helpers import fake_analyte
+from mock import MagicMock
+from clarity_ext.unit_conversion import UnitConversion
 
 
 class TestArtifact(unittest.TestCase):
@@ -50,3 +52,15 @@ class TestArtifact(unittest.TestCase):
     def test_backward_udf_map_empty_if_no_udf_map(self):
         artifact = Artifact()
         self.assertEqual(artifact.udf_backward_map, dict())
+
+    def test_unit_conversion(self):
+        def api_resource():
+            api_resource = MagicMock()
+            api_resource.udf = dict()
+            return api_resource
+
+        artifact = Artifact(api_resource=api_resource())
+        artifact.id = 'art1'
+        units = UnitConversion()
+        artifact.set_udf('test_udf', 1234, units.PICO, units.NANO)
+        self.assertEqual(artifact.api_resource.udf['test_udf'], 1.234)


### PR DESCRIPTION
There was a bug, originating from line 38 in artifact. A variable is called (self.units) that is never explicitly initialized in artifact. The derived class ResultFile had it defined but Analyte did not. So if Analyte was to be called with set_udf and a from_unit, the program would crash. 

I removed units from the input argument list, and instantiate it locally in artifact. 