### PR TITLE
Lims 708 source only dilution scheme

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -126,6 +126,17 @@ class ExtensionContext(object):
     def output_result_files(self):
         return self.artifact_service.all_output_files()
 
+    @property
+    def user_initials(self):
+        return self.current_user.initials
+
+    @property
+    def pid(self):
+        return self.session.current_step_id
+
+    def today(self, format):
+        return datetime.date.today().strftime(format)
+
     def update(self, obj):
         """Add an object that has a commit method to the list of objects to update"""
         self._update_queue.append(obj)

--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -132,15 +132,8 @@ class ExtensionContext(object):
         return self.artifact_service.all_output_files()
 
     @property
-    def user_initials(self):
-        return self.current_user.initials
-
-    @property
     def pid(self):
         return self.session.current_step_id
-
-    def today(self, format):
-        return datetime.date.today().strftime(format)
 
     def update(self, obj):
         """Add an object that has a commit method to the list of objects to update"""

--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -20,7 +20,7 @@ class ExtensionContext(object):
     able to access the underlying services if needed.
     """
 
-    def __init__(self, session, artifact_service, file_service, cache=False, logger=None):
+    def __init__(self, session, artifact_service, file_service, current_user, cache=False, logger=None):
         """
         Initializes the context.
 
@@ -39,6 +39,7 @@ class ExtensionContext(object):
         self.current_step = session.current_step
         self.artifact_service = artifact_service
         self.file_service = file_service
+        self.current_user = current_user
         self.response = None
 
     @staticmethod
@@ -51,9 +52,10 @@ class ExtensionContext(object):
         session = ClaritySession.create(step_id)
         step_repo = StepRepository(session)
         artifact_service = ArtifactService(step_repo)
+        current_user = step_repo.current_user()
         file_repository = FileRepository(session)
         file_service = FileService(artifact_service, file_repository, False)
-        return ExtensionContext(session, artifact_service, file_service, cache=cache)
+        return ExtensionContext(session, artifact_service, file_service, current_user, cache=cache)
 
     @lazyprop
     def dilution_scheme(self):

--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -1,5 +1,5 @@
 import logging
-from clarity_ext.dilution import *
+from clarity_ext.dilution import DilutionScheme, SourceOnlyDilutionScheme
 from clarity_ext import UnitConversion
 from clarity_ext.repository.file_repository import FileRepository
 from clarity_ext.utils import lazyprop
@@ -7,6 +7,7 @@ from clarity_ext import ClaritySession
 from clarity_ext.service import ArtifactService, FileService
 from clarity_ext.repository import StepRepository
 from clarity_ext import utils
+import datetime
 
 
 class ExtensionContext(object):
@@ -61,6 +62,10 @@ class ExtensionContext(object):
     def dilution_scheme(self):
         # TODO: The caller needs to provide the robot
         return DilutionScheme(self.artifact_service, "Hamilton")
+
+    @lazyprop
+    def source_only_dilution_scheme(self):
+        return SourceOnlyDilutionScheme(self.artifact_service, "Hamilton")
 
     @lazyprop
     def shared_files(self):

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -111,8 +111,6 @@ class DilutionScheme(object):
         """
         pairs = artifact_service.all_analyte_pairs()
 
-        self.current_step_id = artifact_service.step_repository.session.current_step_id
-
         # TODO: Is it safe to just check for the container for the first output
         # analyte?
         container = pairs[0].output_artifact.container
@@ -182,10 +180,3 @@ class DilutionScheme(object):
 
     def __str__(self):
         return "<DilutionScheme positioner={}>".format(self.robot_deck_positioner)
-
-    @property
-    def driver_file_name(self):
-        # TODO: Fetch user initials
-        pid = self.current_step_id
-        today = datetime.date.today().strftime("%y%m%d")
-        return "DriverFile_EEX_{}_{}".format(today, pid)

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -8,6 +8,7 @@ class TransferEndpoint(object):
     TransferEndpoint wraps an source or destination analyte involved in a dilution
     """
     # TODO: Handle tube racks
+
     def __init__(self, analyte):
         self.sample_name = analyte.name
         self.well = analyte.well
@@ -23,6 +24,7 @@ class TransferEndpoint(object):
 class SingleTransfer(object):
     # Enclose sample data, user input and derived variables for a
     # single row in a dilution
+
     def __init__(self, source_endpoint, destination_endpoint=None):
         self.sample_name = source_endpoint.sample_name
 
@@ -72,6 +74,7 @@ class EndpointPositioner(object):
     Handles positions for all plates and wells for either source or
     destination placement on a robot deck
     """
+
     def __init__(self, robot_name, transfer_endpoints, plate_size, plate_pos_prefix):
         self.robot_name = robot_name
         self._plate_size = plate_size
@@ -134,7 +137,8 @@ class RobotDeckPositioner(object):
         source_endpoints = [dilute.source_endpoint for dilute in dilutes]
         source_positioner = EndpointPositioner(robot_name, source_endpoints,
                                                plate_size, "DNA")
-        destination_endpoints = [dilute.destination_endpoint for dilute in dilutes]
+        destination_endpoints = [
+            dilute.destination_endpoint for dilute in dilutes]
         destination_positioner = EndpointPositioner(
             robot_name, destination_endpoints, plate_size, "END")
 
@@ -164,13 +168,15 @@ class SourceOnlyDilutionScheme(object):
     the source position and a fixed transfer volume is showed in the
     driver file
     """
+
     def __init__(self, artifact_service, robot_name):
         input_analytes = artifact_service.all_input_analytes()
         container = input_analytes[0].container
         self.transfers = self.create_transfers(input_analytes)
         self.analyte_by_transfer = {dilute: analyte for dilute, analyte in
                                     zip(self.transfers, input_analytes)}
-        transfer_endpoints = [dilute.source_endpoint for dilute in self.transfers]
+        transfer_endpoints = [
+            dilute.source_endpoint for dilute in self.transfers]
         self.source_positioner = EndpointPositioner(robot_name, transfer_endpoints,
                                                     container.size, "DNA")
         self.do_positioning()
@@ -184,7 +190,8 @@ class SourceOnlyDilutionScheme(object):
 
     def do_positioning(self):
         for transfer in self.transfers:
-            transfer.source_well_index = self.source_positioner.indexer(transfer.source_well)
+            transfer.source_well_index = self.source_positioner.indexer(
+                transfer.source_well)
             transfer.source_plate_pos = self.source_positioner. \
                 plate_position_map[transfer.source_container.id]
 
@@ -206,8 +213,10 @@ class DilutionScheme(object):
         container = pairs[0].output_artifact.container
         self.transfers = self.create_transfers(pairs)
 
-        self.analyte_pair_by_transfer = {transfer: pair for transfer, pair in zip(self.transfers, pairs)}
-        self.robot_deck_positioner = RobotDeckPositioner(robot_name, self.transfers, container.size)
+        self.analyte_pair_by_transfer = {
+            transfer: pair for transfer, pair in zip(self.transfers, pairs)}
+        self.robot_deck_positioner = RobotDeckPositioner(
+            robot_name, self.transfers, container.size)
 
         self.calculate_transfer_volumes()
         self.do_positioning()
@@ -218,7 +227,8 @@ class DilutionScheme(object):
         for pair in analyte_pairs:
             source_endpoint = TransferEndpoint(pair.input_artifact)
             destination_endpoint = TransferEndpoint(pair.output_artifact)
-            transfers.append(SingleTransfer(source_endpoint, destination_endpoint))
+            transfers.append(SingleTransfer(
+                source_endpoint, destination_endpoint))
         return transfers
 
     def calculate_transfer_volumes(self):
@@ -240,7 +250,8 @@ class DilutionScheme(object):
     def do_positioning(self):
         # Handle positioning
         for transfer in self.transfers:
-            transfer.source_well_index = self.robot_deck_positioner.indexer(transfer.source_well)
+            transfer.source_well_index = self.robot_deck_positioner.indexer(
+                transfer.source_well)
             transfer.source_plate_pos = self.robot_deck_positioner. \
                 source_plate_position_map[transfer.source_container.id]
             transfer.target_well_index = self.robot_deck_positioner.indexer(

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -48,7 +48,8 @@ class Analyte(Artifact):
         pos = ContainerPosition.create(resource.location[1])
         well = Well(pos, container)
         sample = Sample.create_from_rest_resource(resource.samples[0])
-        analyte = Analyte(resource, resource.name, well, sample, analyte_udf_map, resource.id, **kwargs)
+        analyte = Analyte(resource, resource.name, well, sample, analyte_udf_map,
+                          resource.id, **kwargs)
         analyte.api_resource = resource
         well.artifact = analyte
         return analyte

--- a/clarity_ext/domain/user.py
+++ b/clarity_ext/domain/user.py
@@ -1,0 +1,13 @@
+class User:
+
+    def __init__(self, first_name=None, last_name=None, email=None, initials=None):
+        self.first_name = first_name
+        self.last_name = last_name
+        self.email = email
+        self.initials = initials
+
+    @staticmethod
+    def create_from_rest_resource(resource):
+        user = User(first_name=resource.first_name, last_name=resource.last_name,
+                    email=resource.email, initials=resource.initials)
+        return user

--- a/clarity_ext/driverfile.py
+++ b/clarity_ext/driverfile.py
@@ -135,7 +135,8 @@ class DriverFileService:
     def artifact(self):
         artifacts = [shared_file for shared_file in self.extension.context.shared_files
                      if shared_file.name == self.shared_file_name]
-        assert len(artifacts) == 1, "shared file {} could not be found".format(self.shared_file_name)
+        assert len(artifacts) == 1, "shared file {} could not be found".format(
+            self.shared_file_name)
         return artifacts[0]
 
     @staticmethod

--- a/clarity_ext/driverfile.py
+++ b/clarity_ext/driverfile.py
@@ -80,7 +80,6 @@ class GeneralFileService(object):
             self.os_service.mkdir(upload_path)
             # The LIMS does always add a prefix with the artifact ID:
             new_file_name = self.specific_file_service.lims_adapted_file_name()
-            print("driverfile, new_file_name: {}".format(new_file_name))
             new_file_path = os.path.join(upload_path, new_file_name)
             self.os_service.copy_file(local_file, new_file_path)
 
@@ -136,7 +135,7 @@ class DriverFileService:
     def artifact(self):
         artifacts = [shared_file for shared_file in self.extension.context.shared_files
                      if shared_file.name == self.shared_file_name]
-        assert len(artifacts) == 1
+        assert len(artifacts) == 1, "shared file {} could not be found".format(self.shared_file_name)
         return artifacts[0]
 
     @staticmethod

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -3,6 +3,7 @@ from clarity_ext.domain.analyte import Analyte
 from clarity_ext.domain.result_file import ResultFile
 from clarity_ext.repository.container_repository import ContainerRepository
 from genologics.entities import Artifact as ApiArtifact
+from clarity_ext.domain.user import User
 import copy
 
 
@@ -150,6 +151,11 @@ class StepRepository(object):
     def _retrieve_updated_fields(self, updated_artifact):
         orig_art = self.orig_state_cache[updated_artifact.id]
         return updated_artifact.differing_fields(orig_art)
+
+    def current_user(self):
+        current_user_resource = self.session.current_step.technician
+        return User.create_from_rest_resource(current_user_resource)
+
 
 
 

--- a/test/integration/integration_test_service.py
+++ b/test/integration/integration_test_service.py
@@ -1,4 +1,5 @@
 """Help classes to manage integration tests"""
+from itertools import chain
 
 
 class IntegrationTest:
@@ -21,8 +22,9 @@ class IntegrationTestPrepare:
         self.update_matrix = update_matrix
 
     def prepare(self, artifact_service):
-        input_artifacts = artifact_service.all_input_artifacts()
-        artifact_dict = {artifact.id: artifact for artifact in input_artifacts}
+        artifacts = chain(artifact_service.all_input_artifacts(),
+                          artifact_service.all_output_artifacts())
+        artifact_dict = {artifact.id: artifact for artifact in artifacts}
         self._check_artifacts_exists(artifact_dict)
         update_queue = []
         for update_row in self.update_matrix:

--- a/test/unit/clarity_ext/dilution/test_dilutions.py
+++ b/test/unit/clarity_ext/dilution/test_dilutions.py
@@ -32,7 +32,7 @@ class TestDilutionScheme(unittest.TestCase):
              round(dilute.sample_volume, 1),
              round(dilute.buffer_volume, 1),
              dilute.target_well_index,
-             dilute.target_plate_pos] for dilute in dilution_scheme.dilutes
+             dilute.target_plate_pos] for dilute in dilution_scheme.transfers
         ]
 
         validation_results = list(dilution_scheme.validate())

--- a/test/unit/clarity_ext/dilution/test_update_fields.py
+++ b/test/unit/clarity_ext/dilution/test_update_fields.py
@@ -16,10 +16,12 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
         for dilute in self.dilution_scheme.transfers:
             # Make preparation, fetch the analyte to be updated
             source_analyte = analyte_pair_by_dilute[dilute].input_artifact
-            destination_analyte = analyte_pair_by_dilute[dilute].output_artifact
+            destination_analyte = analyte_pair_by_dilute[
+                dilute].output_artifact
 
             # Update fields for analytes
-            source_analyte.volume = dilute.source_initial_volume - dilute.requested_volume - DILUTION_WASTE_VOLUME
+            source_analyte.volume = dilute.source_initial_volume - \
+                dilute.requested_volume - DILUTION_WASTE_VOLUME
 
             destination_analyte.concentration = dilute.requested_concentration
 
@@ -28,14 +30,16 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
     def test_source_volume_update_1(self):
         dilute = self.dilution_scheme.transfers[0]
         expected = 9.0
-        outcome = self.dilution_scheme.analyte_pair_by_transfer[dilute].input_artifact.volume
+        outcome = self.dilution_scheme.analyte_pair_by_transfer[
+            dilute].input_artifact.volume
         print(dilute.sample_name)
         self.assertEqual(expected, outcome)
 
     def test_source_volume_update_all(self):
         source_volume_sum = 0
         for dilute in self.dilution_scheme.transfers:
-            outcome = self.dilution_scheme.analyte_pair_by_transfer[dilute].input_artifact.volume
+            outcome = self.dilution_scheme.analyte_pair_by_transfer[
+                dilute].input_artifact.volume
             source_volume_sum += outcome
         expected_sum = 96.0
         self.assertEqual(expected_sum, source_volume_sum)

--- a/test/unit/clarity_ext/dilution/test_update_fields.py
+++ b/test/unit/clarity_ext/dilution/test_update_fields.py
@@ -1,8 +1,7 @@
 import unittest
 from clarity_ext.dilution import DILUTION_WASTE_VOLUME
-from test.unit.clarity_ext.helpers import fake_analyte
 from mock import MagicMock
-from clarity_ext.dilution import DilutionScheme, Dilute
+from clarity_ext.dilution import DilutionScheme
 from test.unit.clarity_ext import helpers
 
 
@@ -13,30 +12,30 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
         svc = helpers.mock_two_containers_artifact_service()
         self.dilution_scheme = DilutionScheme(svc, "Hamilton")
 
-        analyte_pair_by_dilute = self.dilution_scheme.analyte_pair_by_dilute
-        for dilute in self.dilution_scheme.dilutes:
+        analyte_pair_by_dilute = self.dilution_scheme.analyte_pair_by_transfer
+        for dilute in self.dilution_scheme.transfers:
             # Make preparation, fetch the analyte to be updated
             source_analyte = analyte_pair_by_dilute[dilute].input_artifact
             destination_analyte = analyte_pair_by_dilute[dilute].output_artifact
 
             # Update fields for analytes
-            source_analyte.volume = dilute.source_initial_volume - dilute.target_volume - DILUTION_WASTE_VOLUME
+            source_analyte.volume = dilute.source_initial_volume - dilute.requested_volume - DILUTION_WASTE_VOLUME
 
-            destination_analyte.concentration = dilute.target_concentration
+            destination_analyte.concentration = dilute.requested_concentration
 
-            destination_analyte.volume = dilute.target_volume
+            destination_analyte.volume = dilute.requested_volume
 
     def test_source_volume_update_1(self):
-        dilute = self.dilution_scheme.dilutes[0]
+        dilute = self.dilution_scheme.transfers[0]
         expected = 9.0
-        outcome = self.dilution_scheme.analyte_pair_by_dilute[dilute].input_artifact.volume
+        outcome = self.dilution_scheme.analyte_pair_by_transfer[dilute].input_artifact.volume
         print(dilute.sample_name)
         self.assertEqual(expected, outcome)
 
     def test_source_volume_update_all(self):
         source_volume_sum = 0
-        for dilute in self.dilution_scheme.dilutes:
-            outcome = self.dilution_scheme.analyte_pair_by_dilute[dilute].input_artifact.volume
+        for dilute in self.dilution_scheme.transfers:
+            outcome = self.dilution_scheme.analyte_pair_by_transfer[dilute].input_artifact.volume
             source_volume_sum += outcome
         expected_sum = 96.0
         self.assertEqual(expected_sum, source_volume_sum)

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -1,7 +1,13 @@
-from clarity_ext.domain import Container, Analyte, Well, ContainerPosition, Sample, Artifact
+from clarity_ext.domain import Container, Analyte, Well, ContainerPosition, Sample, Artifact, ResultFile
 from mock import MagicMock
 from clarity_ext.service import ArtifactService, FileService
 from clarity_ext.repository.step_repository import DEFAULT_UDF_MAP
+
+
+def fake_result_file(artifact_id=None):
+    udf_map = dict()
+    api_resource = MagicMock()
+    return ResultFile(api_resource, udf_map, artifact_id)
 
 
 def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_name=None,
@@ -25,8 +31,9 @@ def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_na
     sample = Sample(sample_id)
     api_resource = None
     udf_map = DEFAULT_UDF_MAP['Analyte']
-    analyte = Analyte(api_resource=api_resource, name=analyte_name, well=well,
-                      sample=sample, artifact_specific_udf_map=udf_map, **kwargs)
+    analyte = Analyte(api_resource=api_resource,
+                      name=analyte_name, well=well, sample=sample,
+                      artifact_specific_udf_map=udf_map, **kwargs)
     analyte.id = artifact_id
     analyte.is_input = is_input
     analyte.generation_type = Artifact.PER_INPUT

--- a/test/unit/clarity_ext/test_context.py
+++ b/test/unit/clarity_ext/test_context.py
@@ -11,14 +11,18 @@ class TestContext(unittest.TestCase):
         session = MagicMock()
         artifact_svc = MagicMock()
         file_svc = MagicMock()
-        context = ExtensionContext(session, artifact_svc, file_svc)
+        current_user = MagicMock()
+        context = ExtensionContext(
+            session, artifact_svc, file_svc, current_user)
         self.assertIsNotNone(context)
 
     def test_input_output_container_throws(self):
         session = MagicMock()
         artifact_svc = helpers.mock_two_containers_artifact_service()
         file_svc = MagicMock()
-        context = ExtensionContext(session, artifact_svc, file_svc)
+        current_user = MagicMock()
+        context = ExtensionContext(
+            session, artifact_svc, file_svc, current_user)
 
         containers = artifact_svc.all_input_containers()
         self.assertEqual(2, len(containers), "Test data not correctly setup")


### PR DESCRIPTION
A dilution class is created, source only dilution scheme,  adapted for a dilution with no output analytes (qPCR). In this step there are only sample measurements as outputs (result_file). These changes have been made:
* Add class for user
* Refactor the Dilute class. Make it deal with units for input and output analytes separately.
* Refactor RobotDeckPositioner. Make it use two instances of the new class EndpointPositioner, which handles all plates for either source or destination. 