### PR TITLE
Lims 686 multiple rows for high volume transfers

### DIFF
--- a/test/unit/clarity_ext/dilution/test_dilutions.py
+++ b/test/unit/clarity_ext/dilution/test_dilutions.py
@@ -41,6 +41,63 @@ class TestDilutionScheme(unittest.TestCase):
         self.assertEqual(expected, actual)
         self.assertEqual(0, len(validation_results))
 
+    def test_scaled_up_volume(self):
+        """
+        Test scaling up volumes when sample volume is < 2 ul
+        1st analyte pair: buffer volume > 0
+        2nd analyte pair: target conc = source conc, volume transfer with v < 2 ul
+        3rd analyte pair: Evaporation with sample volume < 2 ul
+        4th analyte pair: No scaling up, no evaporation
+        """
+        def scaled_up_analyte_set():
+            return [
+                (fake_analyte("cont1", "art1", "sample1", "sample1", "B:2", True,
+                              concentration=200),
+                 fake_analyte("cont2", "art2", "sample1", "sample1", "B:2", False,
+                              target_concentration=10, target_volume=20)),
+                (fake_analyte("cont1", "art3", "sample2", "sample2", "C:2", True,
+                              concentration=10),
+                 fake_analyte("cont2", "art4", "sample2", "sample2", "C:2", False,
+                              target_concentration=10, target_volume=1)),
+                (fake_analyte("cont1", "art5", "sample3", "sample3", "D:2", True,
+                              concentration=20),
+                 fake_analyte("cont2", "art6", "sample3", "sample3", "D:2", False,
+                              target_concentration=40, target_volume=0.5)),
+                (fake_analyte("cont1", "art7", "sample4", "sample4", "E:2", True,
+                              concentration=80),
+                 fake_analyte("cont2", "art8", "sample4", "sample4", "E:2", False,
+                              target_concentration=40, target_volume=10)),
+                    ]
+
+        svc = helpers.mock_artifact_service(scaled_up_analyte_set)
+        dilution_scheme = DilutionScheme(svc, 'Hamilton')
+
+        expected = [
+            ['sample1', 10, 'DNA1', 2.0, 38.0, 10, 'END1'],
+            ['sample2', 11, 'DNA1', 2.0, 0, 11, 'END1'],
+            ['sample3', 12, 'DNA1', 2.0, 0, 12, 'END1'],
+            ['sample4', 13, 'DNA1', 5.0, 5.0, 13, 'END1'],
+        ]
+
+        actual = [
+            [dilute.sample_name,
+             dilute.source_well_index,
+             dilute.source_plate_pos,
+             round(dilute.sample_volume, 1),
+             round(dilute.buffer_volume, 1),
+             dilute.target_well_index,
+             dilute.target_plate_pos] for dilute in dilution_scheme.transfers
+        ]
+        self.assertEqual(dilution_scheme.transfers[0].has_to_evaporate, False)
+        self.assertEqual(dilution_scheme.transfers[1].has_to_evaporate, False)
+        self.assertEqual(dilution_scheme.transfers[2].has_to_evaporate, True)
+        self.assertEqual(dilution_scheme.transfers[3].has_to_evaporate, False)
+        self.assertEqual(dilution_scheme.transfers[0].scaled_up, True)
+        self.assertEqual(dilution_scheme.transfers[1].scaled_up, True)
+        self.assertEqual(dilution_scheme.transfers[2].scaled_up, True)
+        self.assertEqual(dilution_scheme.transfers[3].scaled_up, False)
+        self.assertEqual(expected, actual)
+
     def test_dilution_scheme_for_qpcr(self):
         """Dilution scheme initialized for qPCR dilutions, containing no output analytes"""
         # Setup:
@@ -82,7 +139,6 @@ class TestDilutionScheme(unittest.TestCase):
         # Assert:
         self.assertEqual(expected, actual)
 
-
     # TODO: Add a test for buffer volume validation
     def test_dilution_scheme_too_high_sample_volume(self):
         def invalid_analyte_set():
@@ -113,7 +169,7 @@ class TestDilutionScheme(unittest.TestCase):
                     ]
 
         svc = helpers.mock_artifact_service(invalid_analyte_set)
-        dilution_scheme = DilutionScheme(svc, "Hamilton")
+        dilution_scheme = DilutionScheme(svc, "Hamilton", scale_up_low_volumes=False)
         actual = set(str(result) for result in dilution_scheme.validate())
         expected = set(["Error: Too low sample volume: cont-id1(D5)=>cont-id1(B5)"])
         self.assertEqual(expected, actual)
@@ -157,16 +213,6 @@ class TestDilutionScheme(unittest.TestCase):
         expected = set(["Error: Source concentration not set: cont-id1(D5)"])
         self.assertEqual(expected, actual)
 
-
-def create_real_repo(step_id):
-    """
-    A helper for creating an actual StepRepository. Only needed while the StepRepository is still
-    in its early stages of development
-    """
-    from clarity_ext.clarity import ClaritySession
-    from clarity_ext.repository.step_repository import StepRepository
-    session = ClaritySession.create(step_id)
-    return StepRepository(session)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In driver file generation, split up rows containing more than 50 ul of pipetting volume, either sample volume or buffer volume. 

In addition, scale up sample volumes less than 2 ul (min pipetting volume). This means that the entered target volume from user is also scaled up. 

Small refactoring: Sorting of the transfers are broken out from do_posiitoning, and called explicitly in __init__. Sorting also shows splitted up transfers in an intuitive order, higher volumes first. 