### PR TITLE
Add support for logging

### DIFF
--- a/clarity_ext/driverfile.py
+++ b/clarity_ext/driverfile.py
@@ -4,6 +4,7 @@ import difflib
 from genologics.epp import attach_file
 from genologics.entities import *
 from clarity_ext.utils import lazyprop
+import re
 
 
 class OSService(object):
@@ -29,7 +30,7 @@ class OSService(object):
         shutil.copyfile(source, dest)
 
     def attach_file_for_epp(self, local_file, artifact):
-        attach_file(local_file, artifact)
+        return attach_file(local_file, artifact)
 
 
 class GeneralFileService(object):
@@ -59,7 +60,7 @@ class GeneralFileService(object):
             self.logger.debug("Creating directories {}".format(root))
             self.os_service.makedirs(root)
         full_path = os.path.join(root, self.extension.filename())
-        # The file needs to be openeded in binary form to ensure that Windows line endings are used if specified
+        # The file needs to be opened in binary form to ensure that Windows line endings are used if specified
         with self.os_service.open_file(full_path, 'wb') as f:
             self.logger.debug("Writing output to {}.".format(full_path))
             newline = self.extension.newline()

--- a/clarity_ext/service/__init__.py
+++ b/clarity_ext/service/__init__.py
@@ -1,2 +1,3 @@
 from artifact_service import ArtifactService
 from file_service import FileService
+from step_logger_service import StepLoggerService

--- a/clarity_ext/service/artifact_service.py
+++ b/clarity_ext/service/artifact_service.py
@@ -1,5 +1,6 @@
 from clarity_ext import utils
 from clarity_ext.domain import *
+import logging
 
 
 class ArtifactService:
@@ -9,6 +10,7 @@ class ArtifactService:
 
     def __init__(self, step_repository):
         self.step_repository = step_repository
+        self.logger = logging.getLogger(__name__)
 
     def shared_files(self):
         """

--- a/clarity_ext/service/step_logger_service.py
+++ b/clarity_ext/service/step_logger_service.py
@@ -1,0 +1,60 @@
+import logging
+import time
+from clarity_ext.service.file_service import SharedFileNotFound
+
+
+class StepLoggerService:
+    """
+    The logger service provides logging for files attached in the step.
+
+    Extension writers are exposed to this class via the `ExtensionContext`, which supplies direct
+    access to both logging artifacts, without them having to do anything but ensuring that
+    a file is defined on the step
+    """
+    def __init__(self, step_logger_name, file_service, raise_if_not_found=False, append=True):
+        self.core_logger = logging.getLogger(__name__)
+        self.step_logger_name = step_logger_name
+        self.file_service = file_service
+
+        # Use Windows line endings for now, since most clients are currently Windows.
+        # TODO: This should be configurable.
+        self.NEW_LINE = "\r\n"
+        try:
+            mode = "ab" if append else "wb"
+            self.step_log = self.file_service.local_shared_file(step_logger_name, extension="log",
+                                                                mode=mode, modify_attached=True)
+        except SharedFileNotFound:
+            if raise_if_not_found:
+                raise
+            else:
+                self.step_log = None
+
+    def _log(self, level, msg):
+        if self.step_log:
+            # TODO: Get formatting from the core logging framework
+            if level:
+                self.step_log.write("{} - {} - {}".format(time.strftime("%Y-%m-%d %H:%M:%S"), logging.getLevelName(level), msg + self.NEW_LINE))
+            else:
+                self.step_log.write("{}".format(msg + self.NEW_LINE))
+
+        # Forward to the core logger:
+        if level:
+            self.core_logger.log(level, msg)
+
+    def error(self, msg):
+        self._log(logging.ERROR, msg)
+
+    def warning(self, msg):
+        self._log(logging.WARNING, msg)
+
+    def info(self, msg):
+        self._log(logging.INFO, msg)
+
+    def log(self, msg):
+        # Logs without forwarding to the core logger, and without any formatting
+        self._log(None, msg)
+
+    def get(self, name):
+        # This factory method is added for readability in the extensions.
+        return StepLoggerService(name, self.file_service, raise_if_not_found=True, append=False)
+

--- a/clarity_ext/service/step_logger_service.py
+++ b/clarity_ext/service/step_logger_service.py
@@ -5,11 +5,7 @@ from clarity_ext.service.file_service import SharedFileNotFound
 
 class StepLoggerService:
     """
-    The logger service provides logging for files attached in the step.
-
-    Extension writers are exposed to this class via the `ExtensionContext`, which supplies direct
-    access to both logging artifacts, without them having to do anything but ensuring that
-    a file is defined on the step
+    Provides support for logging to shared files in a step.
     """
     def __init__(self, step_logger_name, file_service, raise_if_not_found=False, append=True):
         self.core_logger = logging.getLogger(__name__)

--- a/clarity_ext/unit_conversion.py
+++ b/clarity_ext/unit_conversion.py
@@ -1,5 +1,4 @@
 import math
-import logging
 
 
 class UnitConversion(object):
@@ -11,18 +10,14 @@ class UnitConversion(object):
         PICO: "p"
     }
 
-    def __init__(self, logger=None):
-        self.logger = logger or logging.getLogger(__name__)
+    def __init__(self):
+        pass
 
     def convert(self, value, unit_from, unit_to):
         if unit_from == unit_to:
             return value
-
         factor = math.pow(10, unit_from - unit_to)
         ret = value * factor
-        if self.logger.isEnabledFor(logging.DEBUG):
-            self.logger.debug("Original: {} {}, Factor: {}, New: {} {}".format(
-                value, self.MAPPING[unit_from], factor, ret, self.MAPPING[unit_to]))
         return ret
 
     def unit_to_string(self, unit):

--- a/test/integration/domain/test_result_file.py
+++ b/test/integration/domain/test_result_file.py
@@ -56,6 +56,7 @@ class TestIntegrationAnalyteRepository(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIsInstance(result, ResultFile)
 
+    @unittest.skip("Step removed")
     def test_can_read_xml(self):
         """Can parse an xml file directly form the context"""
         context = ExtensionContext.create("24-7880")

--- a/test/integration/test_context.py
+++ b/test/integration/test_context.py
@@ -8,6 +8,7 @@ import random
 class TestResultFile(unittest.TestCase):
     """Tests for interacting with result files through the context"""
 
+    @unittest.skip("Step removed")
     def test_can_update_udfs(self):
         def fetch():
             context = ExtensionContext.create("24-7880")

--- a/test/unit/clarity_ext/dilution/test_dilutions.py
+++ b/test/unit/clarity_ext/dilution/test_dilutions.py
@@ -220,6 +220,7 @@ class TestDilutionScheme(unittest.TestCase):
             return inputs, outputs
 
         repo = MagicMock()
+        logger_service = MagicMock()
         repo.all_artifacts = invalid_analyte_set
         svc = ArtifactService(repo)
         dilution_scheme = DilutionScheme(svc, "Hamilton")

--- a/test/unit/clarity_ext/test_context.py
+++ b/test/unit/clarity_ext/test_context.py
@@ -12,8 +12,9 @@ class TestContext(unittest.TestCase):
         artifact_svc = MagicMock()
         file_svc = MagicMock()
         current_user = MagicMock()
+        step_logger_svc = MagicMock()
         context = ExtensionContext(
-            session, artifact_svc, file_svc, current_user)
+            session, artifact_svc, file_svc, current_user, step_logger_svc)
         self.assertIsNotNone(context)
 
     def test_input_output_container_throws(self):
@@ -21,8 +22,8 @@ class TestContext(unittest.TestCase):
         artifact_svc = helpers.mock_two_containers_artifact_service()
         file_svc = MagicMock()
         current_user = MagicMock()
-        context = ExtensionContext(
-            session, artifact_svc, file_svc, current_user)
+        step_logger_svc= MagicMock()
+        context = ExtensionContext(session, artifact_svc, file_svc, current_user, step_logger_svc)
 
         containers = artifact_svc.all_input_containers()
         self.assertEqual(2, len(containers), "Test data not correctly setup")


### PR DESCRIPTION
- Ensures that all calls to the core logging framework end up
  in /opt/clarity-ext/logs on a production server.
- Allows extension writers to write to log files on the step easily