### PR TITLE
Lims 717 updated qpcr

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -1,5 +1,4 @@
-import logging
-from clarity_ext.dilution import DilutionScheme, SourceOnlyDilutionScheme
+from clarity_ext.dilution import DilutionScheme
 from clarity_ext import UnitConversion
 from clarity_ext.repository.file_repository import FileRepository
 from clarity_ext.utils import lazyprop
@@ -7,7 +6,6 @@ from clarity_ext import ClaritySession
 from clarity_ext.service import ArtifactService, FileService, StepLoggerService
 from clarity_ext.repository import StepRepository
 from clarity_ext import utils
-import datetime
 from clarity_ext.driverfile import OSService
 
 
@@ -64,10 +62,6 @@ class ExtensionContext(object):
     def dilution_scheme(self):
         # TODO: The caller needs to provide the robot
         return DilutionScheme(self.artifact_service, "Hamilton")
-
-    @lazyprop
-    def source_only_dilution_scheme(self):
-        return SourceOnlyDilutionScheme(self.artifact_service, "Hamilton")
 
     @lazyprop
     def shared_files(self):

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -1,6 +1,6 @@
 from clarity_ext.domain.validation import ValidationException, ValidationType
-from clarity_ext.utils import lazyprop
 import copy
+from clarity_ext.utils import get_and_apply
 
 DILUTION_WASTE_VOLUME = 1
 ROBOT_MIN_VOLUME = 2
@@ -13,17 +13,18 @@ class TransferEndpoint(object):
     """
     # TODO: Handle tube racks
 
-    def __init__(self, analyte):
-        self.sample_name = analyte.name
-        self.well = analyte.well
-        self.container = analyte.container
-        self.concentration = analyte.concentration
-        self.volume = analyte.volume
-        self.requested_concentration = analyte.target_concentration
-        self.requested_volume = analyte.target_volume
+    def __init__(self, aliquot):
+        self.sample_name = aliquot.name
+        self.well = aliquot.well
+        self.container = aliquot.container
+        self.concentration = aliquot.concentration
+        self.volume = aliquot.volume
+        self.requested_concentration = get_and_apply(
+            aliquot.__dict__, "target_concentration", None, float)
+        self.requested_volume = get_and_apply(
+            aliquot.__dict__, "target_volume", None, float)
         self.well_index = None
         self.plate_pos = None
-
 
 class SingleTransfer(object):
     # Enclose sample data, user input and derived variables for a
@@ -212,14 +213,14 @@ class DilutionScheme(object):
         Calculates all derived values needed in dilute driver file.
         """
         self.scale_up_low_volumes = scale_up_low_volumes
-        pairs = artifact_service.all_analyte_pairs()
+        pairs = artifact_service.all_aliquot_pairs()
 
         # TODO: Is it safe to just check for the container for the first output
         # analyte?
         container = pairs[0].output_artifact.container
         self.transfers = self.create_transfers(pairs)
 
-        self.analyte_pair_by_transfer = {
+        self.aliquot_pair_by_transfer = {
             transfer: pair for transfer, pair in zip(self.transfers, pairs)}
         self.robot_deck_positioner = RobotDeckPositioner(
             robot_name, self.transfers, container.size)
@@ -229,10 +230,10 @@ class DilutionScheme(object):
         self.do_positioning()
         self.sort_transfers()
 
-    def create_transfers(self, analyte_pairs):
+    def create_transfers(self, aliquot_pairs):
         # TODO: handle tube racks
         transfers = []
-        for pair in analyte_pairs:
+        for pair in aliquot_pairs:
             source_endpoint = TransferEndpoint(pair.input_artifact)
             destination_endpoint = TransferEndpoint(pair.output_artifact)
             transfers.append(SingleTransfer(

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -167,44 +167,6 @@ class RobotDeckPositioner(object):
                                                           width=self._plate_size.width)
 
 
-class SourceOnlyDilutionScheme(object):
-    """
-    Creates a dilution scheme for a source only dilution (qPCR)
-    Here, the destination position doesn't matter. Only columns for
-    the source position and a fixed transfer volume is showed in the
-    driver file
-    """
-
-    def __init__(self, artifact_service, robot_name):
-        input_analytes = artifact_service.all_input_analytes()
-        container = input_analytes[0].container
-        self.transfers = self.create_transfers(input_analytes)
-        self.analyte_by_transfer = {dilute: analyte for dilute, analyte in
-                                    zip(self.transfers, input_analytes)}
-        transfer_endpoints = [
-            dilute.source_endpoint for dilute in self.transfers]
-        self.source_positioner = EndpointPositioner(robot_name, transfer_endpoints,
-                                                    container.size, "DNA")
-        self.do_positioning()
-
-    def create_transfers(self, input_analytes):
-        transfers = []
-        for analyte in input_analytes:
-            source_endpoint = TransferEndpoint(analyte)
-            transfers.append(SingleTransfer(source_endpoint))
-        return transfers
-
-    def do_positioning(self):
-        for transfer in self.transfers:
-            transfer.source_well_index = self.source_positioner.indexer(
-                transfer.source_well)
-            transfer.source_plate_pos = self.source_positioner. \
-                plate_position_map[transfer.source_container.id]
-
-        self.transfers = sorted(self.transfers,
-                                key=lambda curr_dil: self.source_positioner.find_sort_number(curr_dil))
-
-
 class DilutionScheme(object):
     """Creates a dilution scheme, given input and output analytes."""
 

--- a/clarity_ext/domain/aliquot.py
+++ b/clarity_ext/domain/aliquot.py
@@ -1,6 +1,7 @@
 from clarity_ext.domain.artifact import Artifact
 from clarity_ext.utils import get_and_apply
 from clarity_ext.domain.common import DomainObjectMixin
+from clarity_ext.domain.container import ContainerPosition
 
 
 class Aliquot(Artifact):
@@ -15,11 +16,32 @@ class Aliquot(Artifact):
         self.is_input = is_input
         if well:
             self.container = well.container
+            well.artifact = self
         else:
             self.container = None
         self.concentration = get_and_apply(
             kwargs, "concentration", None, float)
         self.volume = get_and_apply(kwargs, "volume", None, float)
+
+    @staticmethod
+    def create_well_from_rest(resource, container_repo):
+        # TODO: Batch call
+        try:
+            container = container_repo.get_container(resource.location[0])
+        except AttributeError:
+            pass
+            container = None
+        try:
+            pos = ContainerPosition.create(resource.location[1])
+        except (AttributeError, ValueError):
+            pass
+            pos = None
+
+        well = None
+        if container and pos:
+            well = container.wells[pos]
+
+        return well
 
 
 class Sample(DomainObjectMixin):

--- a/clarity_ext/domain/aliquot.py
+++ b/clarity_ext/domain/aliquot.py
@@ -45,6 +45,7 @@ class Aliquot(Artifact):
 
 
 class Sample(DomainObjectMixin):
+
     def __init__(self, sample_id):
         self.id = sample_id
 

--- a/clarity_ext/domain/aliquot.py
+++ b/clarity_ext/domain/aliquot.py
@@ -1,0 +1,35 @@
+from clarity_ext.domain.artifact import Artifact
+from clarity_ext.utils import get_and_apply
+from clarity_ext.domain.common import DomainObjectMixin
+
+
+class Aliquot(Artifact):
+
+    def __init__(self, api_resource, is_input, id=None, sample=None, name=None, well=None,
+                 artifact_specific_udf_map=None, **kwargs):
+        super(Aliquot, self).__init__(
+            api_resource=api_resource, id=id, name=name,
+            artifact_specific_udf_map=artifact_specific_udf_map)
+        self.sample = sample
+        self.well = well
+        self.is_input = is_input
+        if well:
+            self.container = well.container
+        else:
+            self.container = None
+        self.concentration = get_and_apply(
+            kwargs, "concentration", None, float)
+        self.volume = get_and_apply(kwargs, "volume", None, float)
+
+
+class Sample(DomainObjectMixin):
+    def __init__(self, sample_id):
+        self.id = sample_id
+
+    def __repr__(self):
+        return "<Sample id={}>".format(self.id)
+
+    @staticmethod
+    def create_from_rest_resource(resource):
+        sample = Sample(resource.id)
+        return sample

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -18,8 +18,10 @@ class Analyte(Aliquot):
         super(self.__class__, self).__init__(api_resource, is_input=is_input, id=id,
                                              sample=sample, name=name, well=well,
                                              artifact_specific_udf_map=artifact_specific_udf_map, **kwargs)
-        self.target_concentration = get_and_apply(kwargs, "target_concentration", None, float)
-        self.target_volume = get_and_apply(kwargs, "target_volume", None, float)
+        self.target_concentration = get_and_apply(
+            kwargs, "target_concentration", None, float)
+        self.target_volume = get_and_apply(
+            kwargs, "target_volume", None, float)
 
     def __repr__(self):
         return "{} ({})".format(self.name, self.id)
@@ -38,7 +40,8 @@ class Analyte(Aliquot):
         analyte_udf_map = udf_map.get("Analyte", None)
         kwargs = {key: resource.udf.get(
             analyte_udf_map[key], None) for key in analyte_udf_map}
-        well = Aliquot.create_well_from_rest(resource=resource, container_repo=container_repo)
+        well = Aliquot.create_well_from_rest(
+            resource=resource, container_repo=container_repo)
 
         # TODO: sample should be put in a lazy property, and all samples in a step should be
         # loaded in one batch

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -1,4 +1,3 @@
-from clarity_ext.domain.container import Well
 from clarity_ext.utils import get_and_apply
 from clarity_ext.domain.aliquot import Aliquot, Sample
 
@@ -37,9 +36,10 @@ class Analyte(Aliquot):
         # Map UDFs (which may be using different names in different Clarity setups)
         # to a key-value list with well-defined key names:
         analyte_udf_map = udf_map.get("Analyte", None)
-        kwargs = {key: resource.udf.get(analyte_udf_map[key], None) for key in analyte_udf_map}
-        # TODO: Batch call
-        well = Well.create_from_rest_resource(api_resource=resource, container_repo=container_repo)
+        kwargs = {key: resource.udf.get(
+            analyte_udf_map[key], None) for key in analyte_udf_map}
+        well = Aliquot.create_well_from_rest(resource=resource, container_repo=container_repo)
+
         # TODO: sample should be put in a lazy property, and all samples in a step should be
         # loaded in one batch
         sample = Sample.create_from_rest_resource(resource.samples[0])
@@ -47,7 +47,7 @@ class Analyte(Aliquot):
                           sample=sample, name=resource.name,
                           well=well, artifact_specific_udf_map=analyte_udf_map, **kwargs)
         analyte.api_resource = resource
-        well.artifact = analyte
+
         return analyte
 
     def updated_rest_resource(self, original_rest_resource, updated_fields):

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -1,10 +1,9 @@
-from clarity_ext.domain.container import ContainerPosition, Well
+from clarity_ext.domain.container import Well
 from clarity_ext.utils import get_and_apply
-from clarity_ext.domain.common import DomainObjectMixin
-from clarity_ext.domain.artifact import Artifact
+from clarity_ext.domain.aliquot import Aliquot, Sample
 
 
-class Analyte(Artifact):
+class Analyte(Aliquot):
     """
     Describes an Analyte in the Clarity LIMS system.
 
@@ -12,44 +11,41 @@ class Analyte(Artifact):
     in udf_map, so they can be overridden in different installations.
     """
 
-    def __init__(self, api_resource, name=None, well=None, sample=None,
-                 artifact_specific_udf_map=None, id=None, **kwargs):
+    def __init__(self, api_resource, is_input, id=None, sample=None, name=None, well=None,
+                 artifact_specific_udf_map=None, **kwargs):
         """
         Creates an analyte
         """
-        super(self.__class__, self).__init__(api_resource, artifact_specific_udf_map)
-        self.name = name
-        self.well = well
-        self.container = well.container
-        self.sample = sample
-        self.id = id
-        self.concentration = get_and_apply(kwargs, "concentration", None, float)
+        super(self.__class__, self).__init__(api_resource, is_input=is_input, id=id,
+                                             sample=sample, name=name, well=well,
+                                             artifact_specific_udf_map=artifact_specific_udf_map, **kwargs)
         self.target_concentration = get_and_apply(kwargs, "target_concentration", None, float)
-        self.volume = get_and_apply(kwargs, "volume", None, float)
         self.target_volume = get_and_apply(kwargs, "target_volume", None, float)
 
     def __repr__(self):
         return "{} ({})".format(self.name, self.id)
 
     @staticmethod
-    def create_from_rest_resource(resource, udf_map, container_repo):
+    def create_from_rest_resource(resource, is_input, udf_map, container_repo):
         """
         Creates an Analyte from the rest resource. By default, the container
         is created from the related container resource, except if one
         already exists in the container map. This way, there will be created
         only one container object for each id
         """
-        container = container_repo.get_container(resource.location[0])
 
         # Map UDFs (which may be using different names in different Clarity setups)
         # to a key-value list with well-defined key names:
-        analyte_udf_map = udf_map["Analyte"]
+        analyte_udf_map = udf_map.get("Analyte", None)
         kwargs = {key: resource.udf.get(analyte_udf_map[key], None) for key in analyte_udf_map}
-        pos = ContainerPosition.create(resource.location[1])
-        well = Well(pos, container)
+        # TODO: Batch call
+        well = Well.create_from_rest_resource(api_resource=resource, container_repo=container_repo)
+        # TODO: sample should be put in a lazy property, and all samples in a step should be
+        # loaded in one batch
         sample = Sample.create_from_rest_resource(resource.samples[0])
-        analyte = Analyte(resource, resource.name, well, sample, analyte_udf_map,
-                          resource.id, **kwargs)
+        analyte = Analyte(api_resource=resource, is_input=is_input, id=resource.id,
+                          sample=sample, name=resource.name,
+                          well=well, artifact_specific_udf_map=analyte_udf_map, **kwargs)
         analyte.api_resource = resource
         well.artifact = analyte
         return analyte
@@ -67,17 +63,4 @@ class Analyte(Artifact):
         if 'name' in updated_fields:
             _updated_rest_resource.name = self.assigner.register_assign('name', self.name)
         return _updated_rest_resource, self.assigner.consume()
-
-
-class Sample(DomainObjectMixin):
-    def __init__(self, sample_id):
-        self.id = sample_id
-
-    def __repr__(self):
-        return "<Sample id={}>".format(self.id)
-
-    @staticmethod
-    def create_from_rest_resource(resource):
-        sample = Sample(resource.id)
-        return sample
 

--- a/clarity_ext/domain/artifact.py
+++ b/clarity_ext/domain/artifact.py
@@ -16,9 +16,11 @@ class Artifact(DomainObjectMixin):
     OUTPUT_TYPE_ANALYTE = 2
     OUTPUT_TYPE_SHARED_RESULT_FILE = 3
 
-    def __init__(self, api_resource=None, artifact_specific_udf_map=None):
+    def __init__(self, api_resource=None, id=None, name=None, artifact_specific_udf_map=None):
+        self.id = id
         self.is_input = None  # Set to true if this is an input artifact
         self.generation_type = None  # Set to PER_INPUT or PER_ALL_INPUTS if applicable
+        self.name = name
         if artifact_specific_udf_map:
             self.udf_map = artifact_specific_udf_map
         else:

--- a/clarity_ext/domain/container.py
+++ b/clarity_ext/domain/container.py
@@ -36,16 +36,6 @@ class Well(DomainObjectMixin):
         # The position is 1-indexed
         return (self.position.col - 1) * self.container.size.height + self.position.row
 
-    @staticmethod
-    def create_from_rest_resource(api_resource, container_repo):
-        try:
-            container = container_repo.get_container(api_resource.location[0])
-            pos = ContainerPosition.create(api_resource.location[1])
-        except AttributeError:
-            return None
-
-        return Well(pos, container)
-
 
 class ContainerPosition(namedtuple("ContainerPosition", ["row", "col"])):
     """Defines the position of the plate, (zero based)"""
@@ -116,7 +106,7 @@ class Container(DomainObjectMixin):
         return "<Container id={}>".format(self.id)
 
     @classmethod
-    def create_from_rest_resource(cls, resource, artifacts=[]):
+    def create_from_rest_resource(cls, resource, api_artifacts=[]):
         """
         Creates a container based on a resource from the REST API.
         """
@@ -135,7 +125,7 @@ class Container(DomainObjectMixin):
         ret.id = resource.id
         ret.name = resource.name
         ret.size = size
-        for artifact in artifacts:
+        for artifact in api_artifacts:
             ret.set_well(artifact.location[1], artifact)
         return ret
 
@@ -147,6 +137,7 @@ class Container(DomainObjectMixin):
             content = self.mapping[key] if self.mapping and key in self.mapping else None
             pos = ContainerPosition(row=row, col=col)
             ret[(row, col)] = Well(pos, content)
+            ret[(row, col)].container = self
         return ret
 
     def _traverse(self, order=DOWN_FIRST):
@@ -170,25 +161,16 @@ class Container(DomainObjectMixin):
         return list(self.enumerate_wells(order))
 
     def set_well(self, well_pos, artifact_name=None, artifact_id=None, artifact=None):
-        """
-        well_pos should be a string in the format 'B:1'
-        """
-        if type(well_pos) is str:
-            row, col = well_pos.split(":")
-            try:
-                well_pos = int(row), int(col)
-            except ValueError:
-                # Try to parse as "A:1" etc
-                row = ord(row.upper()) - 64
-                well_pos = row, int(col)
 
         if well_pos not in self.wells:
-            raise KeyError("Well id {} is not available in this container (type={})".format(well_pos, self))
+            raise KeyError(
+                "Well id {} is not available in this container (type={})".format(well_pos, self))
 
         self.wells[well_pos].artifact_name = artifact_name
         self.wells[well_pos].artifact_id = artifact_id
         # TODO: Accept only an artifact
         self.wells[well_pos].artifact = artifact
+
 
     def __repr__(self):
         return "{}".format(self.id)

--- a/clarity_ext/domain/container.py
+++ b/clarity_ext/domain/container.py
@@ -36,6 +36,18 @@ class Well(DomainObjectMixin):
         # The position is 1-indexed
         return (self.position.col - 1) * self.container.size.height + self.position.row
 
+    @staticmethod
+    def create_from_rest_resource(api_resource, container_repo):
+        pos = ContainerPosition.create(api_resource.location[1])
+        # Try statement: If testing and not caring for the container repo
+        try:
+            container = container_repo.get_container(api_resource.location[0])
+        except AttributeError:
+            pass
+            container = None
+
+        return Well(pos, container)
+
 
 class ContainerPosition(namedtuple("ContainerPosition", ["row", "col"])):
     """Defines the position of the plate, (zero based)"""

--- a/clarity_ext/domain/container.py
+++ b/clarity_ext/domain/container.py
@@ -38,13 +38,11 @@ class Well(DomainObjectMixin):
 
     @staticmethod
     def create_from_rest_resource(api_resource, container_repo):
-        pos = ContainerPosition.create(api_resource.location[1])
-        # Try statement: If testing and not caring for the container repo
         try:
             container = container_repo.get_container(api_resource.location[0])
+            pos = ContainerPosition.create(api_resource.location[1])
         except AttributeError:
-            pass
-            container = None
+            return None
 
         return Well(pos, container)
 

--- a/clarity_ext/domain/result_file.py
+++ b/clarity_ext/domain/result_file.py
@@ -1,5 +1,4 @@
 from clarity_ext.domain.aliquot import Aliquot, Sample
-from clarity_ext.domain.container import Well
 
 
 class ResultFile(Aliquot):
@@ -21,17 +20,15 @@ class ResultFile(Aliquot):
         result_file_udf_map = udf_map.get('ResultFile', None)
         kwargs = {key: resource.udf.get(result_file_udf_map[key], None)
                   for key in result_file_udf_map}
-        # TODO: Batch call
-        well = Well.create_from_rest_resource(api_resource=resource, container_repo=container_repo)
+
+        well = Aliquot.create_well_from_rest(resource=resource, container_repo=container_repo)
+
         # TODO: sample should be put in a lazy property, and all samples in a step should be
         # loaded in one batch
         sample = Sample.create_from_rest_resource(resource.samples[0])
         ret = ResultFile(api_resource=resource, is_input=is_input,
                          id=resource.id, sample=sample, name=resource.name, well=well,
                          artifact_specific_udf_map=result_file_udf_map, **kwargs)
-
-        if well.container:
-            well.container.set_well(resource.location[1], artifact=ret)
 
         return ret
 

--- a/clarity_ext/domain/result_file.py
+++ b/clarity_ext/domain/result_file.py
@@ -21,7 +21,8 @@ class ResultFile(Aliquot):
         kwargs = {key: resource.udf.get(result_file_udf_map[key], None)
                   for key in result_file_udf_map}
 
-        well = Aliquot.create_well_from_rest(resource=resource, container_repo=container_repo)
+        well = Aliquot.create_well_from_rest(
+            resource=resource, container_repo=container_repo)
 
         # TODO: sample should be put in a lazy property, and all samples in a step should be
         # loaded in one batch

--- a/clarity_ext/domain/shared_result_file.py
+++ b/clarity_ext/domain/shared_result_file.py
@@ -1,0 +1,15 @@
+from clarity_ext.domain.artifact import Artifact
+
+
+class SharedResultFile(Artifact):
+    def __init__(self, api_resource=None, id=None, name=None, artifact_specific_udf_map=None):
+        super(SharedResultFile, self).__init__(
+            api_resource=api_resource, id=id, name=name,
+            artifact_specific_udf_map=artifact_specific_udf_map)
+
+    @staticmethod
+    def create_from_rest_resource(api_resource, udf_map=None):
+        shared_result_file_udf_map = udf_map.get("SharedResultFile")
+        name = api_resource.name
+        return SharedResultFile(api_resource=api_resource, id=api_resource.id, name=name,
+                                artifact_specific_udf_map=shared_result_file_udf_map)

--- a/clarity_ext/domain/shared_result_file.py
+++ b/clarity_ext/domain/shared_result_file.py
@@ -2,6 +2,7 @@ from clarity_ext.domain.artifact import Artifact
 
 
 class SharedResultFile(Artifact):
+
     def __init__(self, api_resource=None, id=None, name=None, artifact_specific_udf_map=None):
         super(SharedResultFile, self).__init__(
             api_resource=api_resource, id=id, name=name,

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -81,17 +81,18 @@ class StepRepository(object):
         # will be created for each object in a call to this method
         input_resource = input_info["uri"]
         output_resource = output_info["uri"]
-        input = self._wrap_artifact(input_resource, container_repo, is_input=True)
-        output = self._wrap_artifact(output_resource, container_repo, is_input=False)
+        output_gen_type = output_info["output-generation-type"]
+        input = self._wrap_artifact(input_resource, container_repo, gen_type="Input", is_input=True)
+        output = self._wrap_artifact(output_resource, container_repo,
+                                     gen_type=output_gen_type, is_input=False)
 
-        gen_type = output_info["output-generation-type"]
-        if gen_type == "PerInput":
+        if output_gen_type == "PerInput":
             output.generation_type = Artifact.PER_INPUT
-        elif gen_type == "PerAllInputs":
+        elif output_gen_type == "PerAllInputs":
             output.generation_type = Artifact.PER_ALL_INPUTS
         else:
             raise NotImplementedError(
-                "Generation type {} is not implemented".format(gen_type))
+                "Generation type {} is not implemented".format(output_gen_type))
 
         output_type = output_info["output-type"]
         if output_type == "ResultFile":

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -82,7 +82,8 @@ class StepRepository(object):
         input_resource = input_info["uri"]
         output_resource = output_info["uri"]
         output_gen_type = output_info["output-generation-type"]
-        input = self._wrap_artifact(input_resource, container_repo, gen_type="Input", is_input=True)
+        input = self._wrap_artifact(
+            input_resource, container_repo, gen_type="Input", is_input=True)
         output = self._wrap_artifact(output_resource, container_repo,
                                      gen_type=output_gen_type, is_input=False)
 
@@ -126,7 +127,8 @@ class StepRepository(object):
         elif artifact.type == "ResultFile" and gen_type == "PerAllInputs":
             return SharedResultFile.create_from_rest_resource(artifact, self.udf_map)
         else:
-            raise Exception("Unknown type and gen_type combination {}, {}".format(artifact.type, gen_type))
+            raise Exception("Unknown type and gen_type combination {}, {}".format(
+                artifact.type, gen_type))
 
     def _wrap_artifacts(self, artifacts):
         for artifact in artifacts:

--- a/clarity_ext/service/artifact_service.py
+++ b/clarity_ext/service/artifact_service.py
@@ -60,7 +60,7 @@ class ArtifactService:
     def all_output_containers(self):
         artifacts_having_container = (artifact.container
                                       for artifact in self.all_output_artifacts()
-                                      if artifact.container is not None)
+                                      if isinstance(artifact, Aliquot) and artifact.container is not None)
         containers = utils.unique(
             artifacts_having_container, lambda item: item.id)
         return list(containers)

--- a/clarity_ext/service/artifact_service.py
+++ b/clarity_ext/service/artifact_service.py
@@ -1,6 +1,7 @@
 from clarity_ext import utils
 from clarity_ext.domain import *
 import logging
+from clarity_ext.domain.shared_result_file import SharedResultFile
 
 
 class ArtifactService:
@@ -20,8 +21,17 @@ class ArtifactService:
         shared_files = (
             outp for outp in outputs if outp.generation_type == Artifact.PER_ALL_INPUTS)
         ret = list(utils.unique(shared_files, lambda f: f.id))
-        assert len(ret) == 0 or isinstance(ret[0], ResultFile)
+        assert len(ret) == 0 or isinstance(ret[0], SharedResultFile)
         return ret
+
+    def all_aliquot_pairs(self):
+        """
+        Returns all aliquots in a step as an artifact pair (input/output)
+        """
+        pairs = self.step_repository.all_artifacts()
+        aliquots_only = filter(lambda pair: isinstance(pair[0], Aliquot)
+                               and isinstance(pair[1], Aliquot), pairs)
+        return [ArtifactPair(i, o) for i, o in aliquots_only]
 
     def all_analyte_pairs(self):
         """

--- a/test/unit/clarity_ext/dilution/test_dilutions.py
+++ b/test/unit/clarity_ext/dilution/test_dilutions.py
@@ -1,6 +1,6 @@
 import unittest
 from mock import MagicMock
-from clarity_ext.dilution import DilutionScheme, SourceOnlyDilutionScheme
+from clarity_ext.dilution import DilutionScheme
 from test.unit.clarity_ext.helpers import fake_analyte, fake_result_file
 from test.unit.clarity_ext import helpers
 from clarity_ext.service import ArtifactService

--- a/test/unit/clarity_ext/dilution/test_dilutions.py
+++ b/test/unit/clarity_ext/dilution/test_dilutions.py
@@ -166,26 +166,30 @@ class TestDilutionScheme(unittest.TestCase):
     def test_dilution_scheme_for_qpcr(self):
         """Dilution scheme initialized for qPCR dilutions, containing no output analytes"""
         # Setup:
-        def only_input_analyte_set():
+        def analyte_result_file_set():
             ret = [
                 (fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5", True,
                               concentration=134, volume=30),
-                 fake_result_file("sample-measurement1")),
+                 fake_result_file(artifact_id="sample-measurement1", name="sample1",
+                                  container_id="cont1", well_key="D:5")),
                 (fake_analyte("cont-id2", "art-id2", "sample2", "art-name2", "A:5", True,
                               concentration=134, volume=40),
-                 fake_result_file("sample-measurement2")),
+                 fake_result_file(artifact_id="sample-measurement2", name="sample2",
+                                  container_id="cont1", well_key="B:7")),
                 (fake_analyte("cont-id2", "art-id3", "sample3", "art-name3", "B:7", True,
                               concentration=134, volume=50),
-                 fake_result_file("sample-measurement3")),
+                 fake_result_file(artifact_id="sample-measurement3", name="sample3",
+                                  container_id="cont1", well_key="B:7")),
                 (fake_analyte("cont-id2", "art-id4", "sample4", "art-name4", "E:12", True,
                               concentration=134, volume=60),
-                 fake_result_file("sample-measurement4")),
+                 fake_result_file(artifact_id="sample-measurement4", name="sample4",
+                                  container_id="cont1", well_key="E:12")),
             ]
             return ret
 
-        svc = helpers.mock_artifact_service(only_input_analyte_set)
+        svc = helpers.mock_artifact_service(analyte_result_file_set)
 
-        dilution_scheme = SourceOnlyDilutionScheme(svc, "Hamilton")
+        dilution_scheme = DilutionScheme(svc, "Hamilton")
 
         expected = [
             ['art-name1', 36, 'DNA1', 4],

--- a/test/unit/clarity_ext/dilution/test_update_fields.py
+++ b/test/unit/clarity_ext/dilution/test_update_fields.py
@@ -12,7 +12,7 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
         svc = helpers.mock_two_containers_artifact_service()
         self.dilution_scheme = DilutionScheme(svc, "Hamilton")
 
-        analyte_pair_by_dilute = self.dilution_scheme.analyte_pair_by_transfer
+        analyte_pair_by_dilute = self.dilution_scheme.aliquot_pair_by_transfer
         for dilute in self.dilution_scheme.transfers:
             # Make preparation, fetch the analyte to be updated
             source_analyte = analyte_pair_by_dilute[dilute].input_artifact
@@ -30,7 +30,7 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
     def test_source_volume_update_1(self):
         dilute = self.dilution_scheme.transfers[0]
         expected = 9.0
-        outcome = self.dilution_scheme.analyte_pair_by_transfer[
+        outcome = self.dilution_scheme.aliquot_pair_by_transfer[
             dilute].input_artifact.volume
         print(dilute.sample_name)
         self.assertEqual(expected, outcome)
@@ -38,7 +38,7 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
     def test_source_volume_update_all(self):
         source_volume_sum = 0
         for dilute in self.dilution_scheme.transfers:
-            outcome = self.dilution_scheme.analyte_pair_by_transfer[
+            outcome = self.dilution_scheme.aliquot_pair_by_transfer[
                 dilute].input_artifact.volume
             source_volume_sum += outcome
         expected_sum = 96.0

--- a/test/unit/clarity_ext/domain/test_artifact.py
+++ b/test/unit/clarity_ext/domain/test_artifact.py
@@ -172,7 +172,8 @@ class TestArtifact(unittest.TestCase):
         self.assertEqual(expected_log, log)
 
     def test_create_from_rest_result_file(self):
-        api_resource = mock_artifact_resource(resouce_id="art1", sample_name="sample1", well_position="B:2")
+        api_resource = mock_artifact_resource(
+            resouce_id="art1", sample_name="sample1", well_position="B:2")
         api_resource.udf = {"conc from udf": 10}
         udf_map = {
             "ResultFile": {"concentration": "conc from udf"}
@@ -206,7 +207,8 @@ class TestArtifact(unittest.TestCase):
                          "sample1")
 
     def test_create_result_file_with_no_container(self):
-        api_resource = mock_artifact_resource(resouce_id="art1", sample_name="sample1")
+        api_resource = mock_artifact_resource(
+            resouce_id="art1", sample_name="sample1")
         api_resource.udf = {"conc from udf": 10}
         udf_map = {
             "ResultFile": {"concentration": "conc from udf"}
@@ -237,7 +239,6 @@ class TestArtifact(unittest.TestCase):
         self.assertEqual(result_file.well.__repr__(),
                          "None")
 
-
     def test_create_from_rest_shared_result_file(self):
         api_resource = MagicMock()
         api_resource.id = "id1"
@@ -247,7 +248,5 @@ class TestArtifact(unittest.TestCase):
             api_resource=api_resource, udf_map=dict())
         expected_shared_result_file = fake_shared_result_file("id1", "name1")
         self.assertEqual(expected_shared_result_file.id, shared_result_file.id)
-        self.assertEqual(expected_shared_result_file.name, shared_result_file.name)
-
-
-
+        self.assertEqual(expected_shared_result_file.name,
+                         shared_result_file.name)

--- a/test/unit/clarity_ext/domain/test_artifact.py
+++ b/test/unit/clarity_ext/domain/test_artifact.py
@@ -1,8 +1,13 @@
 import unittest
-from clarity_ext.domain import Artifact
-from test.unit.clarity_ext.helpers import fake_analyte
+from test.unit.clarity_ext.helpers import fake_analyte, fake_result_file
+from test.unit.clarity_ext.helpers import fake_shared_result_file
 from mock import MagicMock
 from clarity_ext.unit_conversion import UnitConversion
+from clarity_ext.domain import Artifact
+from clarity_ext.domain.analyte import Analyte
+from clarity_ext.domain.result_file import ResultFile
+from clarity_ext.domain.shared_result_file import SharedResultFile
+from clarity_ext.repository.step_repository import StepRepository
 
 
 class TestArtifact(unittest.TestCase):
@@ -64,3 +69,149 @@ class TestArtifact(unittest.TestCase):
         units = UnitConversion()
         artifact.set_udf('test_udf', 1234, units.PICO, units.NANO)
         self.assertEqual(artifact.api_resource.udf['test_udf'], 1.234)
+
+    def test_updated_rest_resource_analyte(self):
+        def fake_analyte(artifact_id=None, is_input=None, **kwargs):
+            udf_map = {"target_concentration": "Target Concentration"}
+            api_resource = MagicMock()
+            api_resource.udf = dict()
+            analyte = Analyte(api_resource, is_input=is_input, id=artifact_id, sample=None, name=None,
+                              well=None, artifact_specific_udf_map=udf_map, **kwargs)
+            return analyte
+
+        analyte1 = fake_analyte("art1", is_input=True, target_concentration=10)
+        analyte2 = fake_analyte("art2", is_input=False)
+        step_repo = StepRepository(session=None, udf_map=None)
+        step_repo._add_to_orig_state_cache([(analyte1, analyte2)])
+        analyte1.target_concentration = 11
+        analyte1.set_udf("Not mapped udf", 2)
+        updated_fields = step_repo._retrieve_updated_fields(analyte1)
+        updated_rest_resource, log = analyte1.updated_rest_resource(
+            analyte1.api_resource, updated_fields)
+
+        expected_log = [("Analyte", "art1", "Target Concentration", "11"),
+                        ("Analyte", "art1", "Not mapped udf", "2")]
+        expected_log = sorted(expected_log)
+        log = sorted(log)
+
+        print("log: {}".format(log))
+        print("expected log: {}".format(expected_log))
+
+        self.assertEqual(expected_log, log)
+
+    def test_create_from_rest_analyte(self):
+        api_resource = MagicMock()
+        api_resource.udf = {"conc from udf": 10}
+        api_resource.location = [None, "B:2"]
+        sample = MagicMock()
+        sample.id = "sample1"
+        api_resource.samples = [sample]
+        api_resource.id = "art1"
+        api_resource.name = "sample1"
+        udf_map = {
+            "Analyte": {"concentration": "conc from udf"}
+        }
+        container_repo = MagicMock()
+        container_repo.get_container.return_value = None
+
+        analyte = Analyte.create_from_rest_resource(
+            api_resource, is_input=True, udf_map=udf_map,
+            container_repo=container_repo)
+
+        expected_analyte = fake_analyte(container_id=None, artifact_id="art1", sample_id="sample1",
+                                        analyte_name="sample1", well_key="B:2", is_input=True,
+                                        concentration=10)
+
+        print("analyte:")
+        for key in analyte.__dict__:
+            print("{}\t{}".format(key, analyte.__dict__[key]))
+        print("\nexpected analyte:")
+        for key in expected_analyte.__dict__:
+            print("{}\t{}".format(key, expected_analyte.__dict__[key]))
+
+        self.assertEqual(expected_analyte.concentration, analyte.concentration)
+        self.assertEqual(expected_analyte.id, analyte.id)
+        self.assertEqual(expected_analyte.name, analyte.name)
+        self.assertEqual(expected_analyte.well.__repr__(),
+                         analyte.well.__repr__())
+
+    def test_updated_rest_resource_result_file(self):
+        def fake_result_file(artifact_id=None, future_field=None):
+            udf_map = {"future_field": "Future Field"}
+            api_resource = MagicMock()
+            api_resource.udf = dict()
+            result_file = ResultFile(api_resource, is_input=False, id=artifact_id, sample=None,
+                                     name=None, well=None, artifact_specific_udf_map=udf_map)
+            result_file.future_field = future_field
+            return result_file
+
+        result_file1 = fake_result_file(artifact_id="art1", future_field=10)
+        analyte2 = fake_result_file("art2")
+        step_repo = StepRepository(session=None, udf_map=None)
+        step_repo._add_to_orig_state_cache([(result_file1, analyte2)])
+        result_file1.future_field = 11
+        result_file1.set_udf("Not mapped udf", 2)
+        updated_fields = step_repo._retrieve_updated_fields(result_file1)
+        updated_rest_resource, log = result_file1.updated_rest_resource(
+            result_file1.api_resource, updated_fields)
+
+        expected_log = [("ResultFile", "art1", "Future Field", "11"),
+                        ("ResultFile", "art1", "Not mapped udf", "2")]
+        expected_log = sorted(expected_log)
+        log = sorted(log)
+
+        print("log: {}".format(log))
+        print("expected log: {}".format(expected_log))
+
+        self.assertEqual(expected_log, log)
+
+    def test_create_from_rest_result_file(self):
+        api_resource = MagicMock()
+        api_resource.udf = {"conc from udf": 10}
+        api_resource.location = [None, "B:2"]
+        sample = MagicMock()
+        sample.id = "sample1"
+        api_resource.samples = [sample]
+        api_resource.id = "art1"
+        api_resource.name = "sample1"
+        udf_map = {
+            "ResultFile": {"concentration": "conc from udf"}
+        }
+        container_repo = MagicMock()
+        container_repo.get_container.return_value = None
+
+        result_file = ResultFile.create_from_rest_resource(
+            api_resource, is_input=True, udf_map=udf_map,
+            container_repo=container_repo)
+
+        expected_result_file = fake_result_file(
+            artifact_id="art1", container_id=None, name="sample1", well_key="B:2",
+            is_input=False, udf_map=udf_map, concentration=10)
+
+        print("result_file:")
+        for key in result_file.__dict__:
+            print("{}\t{}".format(key, result_file.__dict__[key]))
+        print("\nexpected result_file:")
+        for key in expected_result_file.__dict__:
+            print("{}\t{}".format(key, expected_result_file.__dict__[key]))
+
+        self.assertEqual(expected_result_file.concentration,
+                         result_file.concentration)
+        self.assertEqual(expected_result_file.id, result_file.id)
+        self.assertEqual(expected_result_file.name, result_file.name)
+        self.assertEqual(expected_result_file.well.__repr__(),
+                         result_file.well.__repr__())
+
+    def test_create_from_rest_shared_result_file(self):
+        api_resource = MagicMock()
+        api_resource.id = "id1"
+        api_resource.name = "name1"
+
+        shared_result_file = SharedResultFile.create_from_rest_resource(
+            api_resource=api_resource, udf_map=dict())
+        expected_shared_result_file = fake_shared_result_file("id1", "name1")
+        self.assertEqual(expected_shared_result_file.id, shared_result_file.id)
+        self.assertEqual(expected_shared_result_file.name, shared_result_file.name)
+
+
+

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -27,8 +27,12 @@ def fake_result_file(artifact_id=None, name=None, container_id=None, well_key=No
     api_resource = MagicMock()
     if not udf_map:
         udf_map = DEFAULT_UDF_MAP["ResultFile"]
-    return ResultFile(api_resource=api_resource, is_input=is_input, id=artifact_id, sample=None,
+    ret = ResultFile(api_resource=api_resource, is_input=is_input, id=artifact_id, sample=None,
                       name=name, well=well, artifact_specific_udf_map=udf_map, **kwargs)
+
+    if container:
+        container.set_well(well.position, artifact=ret)
+    return ret
 
 
 def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_name=None,
@@ -69,6 +73,27 @@ def fake_container(container_id):
     else:
         container = None
     return container
+
+
+def mock_artifact_resource(resouce_id=None, sample_name=None, well_position=None):
+    api_resource = MagicMock()
+    if well_position:
+        api_resource.location = [None, well_position]
+    sample = MagicMock()
+    sample.id = sample_name
+    api_resource.samples = [sample]
+    api_resource.id = resouce_id
+    api_resource.name = sample_name
+    return api_resource
+
+
+def mock_container_repo(container_id=None):
+    container_repo = MagicMock()
+    container = None
+    if container_id:
+        container = fake_container(container_id=container_id)
+    container_repo.get_container.return_value = container
+    return container_repo
 
 
 def mock_two_containers_artifact_service():

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -28,7 +28,7 @@ def fake_result_file(artifact_id=None, name=None, container_id=None, well_key=No
     if not udf_map:
         udf_map = DEFAULT_UDF_MAP["ResultFile"]
     ret = ResultFile(api_resource=api_resource, is_input=is_input, id=artifact_id, sample=None,
-                      name=name, well=well, artifact_specific_udf_map=udf_map, **kwargs)
+                     name=name, well=well, artifact_specific_udf_map=udf_map, **kwargs)
 
     if container:
         container.set_well(well.position, artifact=ret)

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -1,17 +1,38 @@
-from clarity_ext.domain import Container, Analyte, Well, ContainerPosition, Sample, Artifact, ResultFile
+from clarity_ext.domain import Container
 from mock import MagicMock
 from clarity_ext.service import ArtifactService, FileService
+from clarity_ext.domain.analyte import Analyte
+from clarity_ext.domain.container import Well
+from clarity_ext.domain.container import ContainerPosition
+from clarity_ext.domain.aliquot import Sample
+from clarity_ext.domain.artifact import Artifact
+from clarity_ext.domain.result_file import ResultFile
+from clarity_ext.domain.shared_result_file import SharedResultFile
 from clarity_ext.repository.step_repository import DEFAULT_UDF_MAP
 
 
-def fake_result_file(artifact_id=None):
+def fake_shared_result_file(artifact_id=None, name=None):
     udf_map = dict()
     api_resource = MagicMock()
-    return ResultFile(api_resource, udf_map, artifact_id)
+    return SharedResultFile(api_resource=api_resource,
+                            id=artifact_id, name=name,
+                            artifact_specific_udf_map=udf_map)
+
+
+def fake_result_file(artifact_id=None, name=None, container_id=None, well_key=None,
+                     is_input=None, udf_map=None, **kwargs):
+    container = fake_container(container_id=container_id)
+    pos = ContainerPosition.create(well_key)
+    well = Well(pos, container)
+    api_resource = MagicMock()
+    if not udf_map:
+        udf_map = DEFAULT_UDF_MAP["ResultFile"]
+    return ResultFile(api_resource=api_resource, is_input=is_input, id=artifact_id, sample=None,
+                      name=name, well=well, artifact_specific_udf_map=udf_map, **kwargs)
 
 
 def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_name=None,
-                 well_key=None, is_input=None, **kwargs):
+                 well_key=None, is_input=None, udf_map=None, **kwargs):
     """
     Creates a fake Analyte domain object
 
@@ -23,22 +44,31 @@ def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_na
     :is_input: True if the analyte is an input analyte, False otherwise.
     :kwargs: Any UDF. Use the key names specified in the udf_map being used.
     """
-    container = Container(container_type=Container.CONTAINER_TYPE_96_WELLS_PLATE)
-    container.id = container_id
-    container.name = container_id
+    container = fake_container(container_id)
     pos = ContainerPosition.create(well_key)
     well = Well(pos, container)
     sample = Sample(sample_id)
     api_resource = None
-    udf_map = DEFAULT_UDF_MAP['Analyte']
-    analyte = Analyte(api_resource=api_resource,
+    if not udf_map:
+        udf_map = DEFAULT_UDF_MAP['Analyte']
+    analyte = Analyte(api_resource=api_resource, is_input=is_input,
                       name=analyte_name, well=well, sample=sample,
                       artifact_specific_udf_map=udf_map, **kwargs)
     analyte.id = artifact_id
-    analyte.is_input = is_input
     analyte.generation_type = Artifact.PER_INPUT
     well.artifact = analyte
     return analyte
+
+
+def fake_container(container_id):
+    if container_id:
+        container = Container(
+            container_type=Container.CONTAINER_TYPE_96_WELLS_PLATE)
+        container.id = container_id
+        container.name = container_id
+    else:
+        container = None
+    return container
 
 
 def mock_two_containers_artifact_service():


### PR DESCRIPTION
Prepare clarity ext dilutions for a step configured with input analytes and output result files. (The UI name for result file is sample measurement, which is a more appropriate name for it. ) The input analyte and output result file are forming a pair and should be treated in the same way as an analyte pair. I have created an common base class for them, Aliquot, which is now used in DilutionScheme class. 

Also, make some fixes regarding Well instantiation. Add some tests for create_from_rest_resource (result_file and analyte), and updated_rest_resource


