### PR TITLE
Fix for some broken tests

### DIFF
--- a/clarity_ext/domain/__init__.py
+++ b/clarity_ext/domain/__init__.py
@@ -2,3 +2,4 @@ from clarity_ext.domain.artifact import *
 from clarity_ext.domain.analyte import *
 from clarity_ext.domain.container import *
 from clarity_ext.domain.result_file import *
+from clarity_ext.domain.shared_result_file import *

--- a/clarity_ext/service/artifact_service.py
+++ b/clarity_ext/service/artifact_service.py
@@ -88,7 +88,7 @@ class ArtifactService:
         files = (outp for outp in outputs
                  if outp.output_type == Artifact.OUTPUT_TYPE_RESULT_FILE)
         ret = list(utils.unique(files, lambda f: f.id))
-        assert len(ret) == 0 or isinstance(ret[0], ResultFile)
+        assert len(ret) == 0 or isinstance(ret[0], SharedResultFile)
         return ret
 
     def output_file_by_id(self, file_id):

--- a/test/integration/domain/test_result_file.py
+++ b/test/integration/domain/test_result_file.py
@@ -1,6 +1,5 @@
-import requests_cache
 import unittest
-from clarity_ext.domain import Container, ResultFile
+from clarity_ext.domain import Container, ResultFile, SharedResultFile
 from clarity_ext.context import ExtensionContext
 import os
 
@@ -54,7 +53,7 @@ class TestIntegrationAnalyteRepository(unittest.TestCase):
         context = ExtensionContext.create("24-3144")
         result = context.output_result_file_by_id("92-5244")
         self.assertIsNotNone(result)
-        self.assertIsInstance(result, ResultFile)
+        self.assertIsInstance(result, SharedResultFile)
 
     @unittest.skip("Step removed")
     def test_can_read_xml(self):


### PR DESCRIPTION
An earlier refactoring, which added the SharedResultFile
domain object, seems to have broken three tests.
This fixes that.