### PR TITLE
Fix for some broken tests

### DIFF
--- a/clarity_ext/cli.py
+++ b/clarity_ext/cli.py
@@ -6,6 +6,7 @@ from clarity_ext.integration import IntegrationTestService
 from clarity_ext.extensions import ExtensionService
 import os
 import yaml
+import time
 
 config = None
 logger = None
@@ -36,6 +37,10 @@ def validate(module):
     """
     Validates the extension if there exists frozen data for it.
     Can use regex to match extensions.
+
+    Note that during development, one may have stray *.pyc files
+    hanging around (that don't have a corresponding *.py file)
+    so they need to be cleaned before calling
     """
     import time
     t1 = time.time()

--- a/clarity_ext/domain/__init__.py
+++ b/clarity_ext/domain/__init__.py
@@ -2,3 +2,4 @@ from clarity_ext.domain.artifact import *
 from clarity_ext.domain.analyte import *
 from clarity_ext.domain.container import *
 from clarity_ext.domain.result_file import *
+from clarity_ext.domain.shared_result_file import *

--- a/clarity_ext/service/artifact_service.py
+++ b/clarity_ext/service/artifact_service.py
@@ -88,7 +88,6 @@ class ArtifactService:
         files = (outp for outp in outputs
                  if outp.output_type == Artifact.OUTPUT_TYPE_RESULT_FILE)
         ret = list(utils.unique(files, lambda f: f.id))
-        assert len(ret) == 0 or isinstance(ret[0], ResultFile)
         return ret
 
     def output_file_by_id(self, file_id):

--- a/test/integration/domain/test_result_file.py
+++ b/test/integration/domain/test_result_file.py
@@ -1,6 +1,5 @@
-import requests_cache
 import unittest
-from clarity_ext.domain import Container, ResultFile
+from clarity_ext.domain import Container, ResultFile, SharedResultFile
 from clarity_ext.context import ExtensionContext
 import os
 
@@ -54,7 +53,7 @@ class TestIntegrationAnalyteRepository(unittest.TestCase):
         context = ExtensionContext.create("24-3144")
         result = context.output_result_file_by_id("92-5244")
         self.assertIsNotNone(result)
-        self.assertIsInstance(result, ResultFile)
+        self.assertIsInstance(result, SharedResultFile)
 
     @unittest.skip("Step removed")
     def test_can_read_xml(self):


### PR DESCRIPTION
An earlier commit, seems to have broken three tests.

- In one case an assert has been removed. It ran successfully in the clarity-ext tests but not in the clarity-snpseq tests. It is not required.