### PR TITLE
Filter out blank controls in dilution scheme

### DIFF
--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -230,9 +230,9 @@ class DilutionScheme(object):
                     transfer.buffer_volume *= scale_factor
                     transfer.scaled_up = True
             except (TypeError, ZeroDivisionError) as e:
-                transfer.sample_volume = 0
-                transfer.buffer_volume = 0
-                transfer.has_to_evaporate = False
+                transfer.sample_volume = None
+                transfer.buffer_volume = None
+                transfer.has_to_evaporate = None
 
     def split_up_high_volume_rows(self):
         """

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -19,6 +19,9 @@ class TransferEndpoint(object):
         self.container = aliquot.container
         self.concentration = aliquot.concentration
         self.volume = aliquot.volume
+        self.is_control = False
+        if hasattr(aliquot, "is_control"):
+            self.is_control = aliquot.is_control
         self.requested_concentration = get_and_apply(
             aliquot.__dict__, "target_concentration", None, float)
         self.requested_volume = get_and_apply(
@@ -26,12 +29,15 @@ class TransferEndpoint(object):
         self.well_index = None
         self.plate_pos = None
 
+
 class SingleTransfer(object):
     # Enclose sample data, user input and derived variables for a
     # single row in a dilution
 
-    def __init__(self, source_endpoint, destination_endpoint=None):
+    def __init__(self, source_endpoint, destination_endpoint=None, pair_id=None):
+        self.pair_id = pair_id
         self.sample_name = source_endpoint.sample_name
+        self.is_control = source_endpoint.is_control
 
         self.source_endpoint = source_endpoint
         self.destination_endpoint = destination_endpoint
@@ -180,10 +186,10 @@ class DilutionScheme(object):
         # TODO: Is it safe to just check for the container for the first output
         # analyte?
         container = pairs[0].output_artifact.container
-        self.transfers = self.create_transfers(pairs)
+        all_transfers = self._create_transfers(pairs)
+        self.transfers = list(t for t in all_transfers if t.is_control is False)
 
-        self.aliquot_pair_by_transfer = {
-            transfer: pair for transfer, pair in zip(self.transfers, pairs)}
+        self.aliquot_pair_by_transfer = self._map_pair_and_transfers(pairs=pairs)
         self.robot_deck_positioner = RobotDeckPositioner(
             robot_name, self.transfers, container.size)
 
@@ -192,15 +198,19 @@ class DilutionScheme(object):
         self.do_positioning()
         self.sort_transfers()
 
-    def create_transfers(self, aliquot_pairs):
+    def _create_transfers(self, aliquot_pairs):
         # TODO: handle tube racks
         transfers = []
         for pair in aliquot_pairs:
             source_endpoint = TransferEndpoint(pair.input_artifact)
             destination_endpoint = TransferEndpoint(pair.output_artifact)
             transfers.append(SingleTransfer(
-                source_endpoint, destination_endpoint))
+                source_endpoint, destination_endpoint, pair_id=id(pair)))
         return transfers
+
+    def _map_pair_and_transfers(self, pairs):
+        pair_dict = {id(pair): pair for pair in pairs}
+        return {transfer: pair_dict[transfer.pair_id] for transfer in self.transfers}
 
     def calculate_transfer_volumes(self):
         # Handle volumes etc.
@@ -220,9 +230,9 @@ class DilutionScheme(object):
                     transfer.buffer_volume *= scale_factor
                     transfer.scaled_up = True
             except (TypeError, ZeroDivisionError) as e:
-                transfer.sample_volume = None
-                transfer.buffer_volume = None
-                transfer.has_to_evaporate = None
+                transfer.sample_volume = 0
+                transfer.buffer_volume = 0
+                transfer.has_to_evaporate = False
 
     def split_up_high_volume_rows(self):
         """

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -12,7 +12,7 @@ class Analyte(Aliquot):
     """
 
     def __init__(self, api_resource, is_input, id=None, samples=None, name=None, well=None,
-                 artifact_specific_udf_map=None, **kwargs):
+                 is_control=False, artifact_specific_udf_map=None, **kwargs):
         """
         Creates an analyte
         """
@@ -23,6 +23,7 @@ class Analyte(Aliquot):
             kwargs, "target_concentration", None, float)
         self.target_volume = get_and_apply(
             kwargs, "target_volume", None, float)
+        self.is_control = is_control
 
     def __repr__(self):
         return "{} ({})".format(self.name, self.id)
@@ -47,9 +48,14 @@ class Analyte(Aliquot):
         # TODO: sample should be put in a lazy property, and all samples in a step should be
         # loaded in one batch
         samples = [Sample.create_from_rest_resource(sample) for sample in resource.samples]
+        is_control = False
+        # TODO: This code principally belongs to the genologics layer, but 'control-type' does not exist there
+        if resource.root.find("control-type") is not None:
+            is_control = True
         analyte = Analyte(api_resource=resource, is_input=is_input, id=resource.id,
                           samples=samples, name=resource.name,
-                          well=well, artifact_specific_udf_map=analyte_udf_map, **kwargs)
+                          well=well, is_control=is_control,
+                          artifact_specific_udf_map=analyte_udf_map, **kwargs)
         analyte.api_resource = resource
         analyte.reagent_labels = resource.reagent_labels
 

--- a/test/unit/clarity_ext/dilution/test_update_fields.py
+++ b/test/unit/clarity_ext/dilution/test_update_fields.py
@@ -3,13 +3,13 @@ from clarity_ext.dilution import DILUTION_WASTE_VOLUME
 from mock import MagicMock
 from clarity_ext.dilution import DilutionScheme
 from test.unit.clarity_ext import helpers
+from test.unit.clarity_ext.helpers import fake_analyte
 
 
 class UpdateFieldsForDilutionTests(unittest.TestCase):
 
     def setUp(self):
-        repo = MagicMock()
-        svc = helpers.mock_two_containers_artifact_service()
+        svc = helpers.mock_artifact_service(analyte_set_with_blank)
         self.dilution_scheme = DilutionScheme(svc, "Hamilton")
 
         analyte_pair_by_dilute = self.dilution_scheme.aliquot_pair_by_transfer
@@ -27,9 +27,10 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
 
             destination_analyte.volume = dilute.requested_volume
 
+
     def test_source_volume_update_1(self):
-        dilute = self.dilution_scheme.transfers[0]
-        expected = 9.0
+        dilute = self.dilution_scheme.transfers[-1]
+        expected = 29.0
         outcome = self.dilution_scheme.aliquot_pair_by_transfer[
             dilute].input_artifact.volume
         print(dilute.sample_name)
@@ -41,5 +42,34 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
             outcome = self.dilution_scheme.aliquot_pair_by_transfer[
                 dilute].input_artifact.volume
             source_volume_sum += outcome
-        expected_sum = 96.0
+        expected_sum = 57.0
         self.assertEqual(expected_sum, source_volume_sum)
+
+    def test_dilute_aliqout_matching(self):
+        aliquot_pair_by_transfer = self.dilution_scheme.aliquot_pair_by_transfer
+        for transfer in self.dilution_scheme.transfers:
+            source_aliquot = aliquot_pair_by_transfer[transfer].input_artifact
+            print("transfer sample name: {}".format(transfer.sample_name))
+            print("source aliquot sample name: {}".format(source_aliquot.name))
+            self.assertEqual(transfer.sample_name, source_aliquot.name)
+
+
+def analyte_set_with_blank():
+    return [
+        (fake_analyte("cont1", "art7", "sample4", "sample4", "E:2", True, is_control=True),
+         fake_analyte("cont2", "art8", "sample4", "sample4", "E:2", False, is_control=True,
+                      target_concentration=100, target_volume=20)),
+        (fake_analyte("cont1", "art1", "sample1", "sample1", "B:2", True,
+                      concentration=100, volume=30),
+         fake_analyte("cont2", "art2", "sample1", "sample1", "B:2", False,
+                      target_concentration=100, target_volume=20)),
+        (fake_analyte("cont1", "art3", "sample2", "sample2", "C:2", True,
+                      concentration=100, volume=40),
+         fake_analyte("cont2", "art4", "sample2", "sample2", "C:2", False,
+                      target_concentration=100, target_volume=20)),
+        (fake_analyte("cont1", "art5", "sample3", "sample3", "D:2", True,
+                      concentration=100, volume=50),
+         fake_analyte("cont2", "art6", "sample3", "sample3", "D:2", False,
+                      target_concentration=100, target_volume=20)),
+    ]
+

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -1,5 +1,7 @@
 from clarity_ext.domain import Container
 from mock import MagicMock
+from mock import patch
+from mock import PropertyMock
 from clarity_ext.service import ArtifactService, FileService
 from clarity_ext.domain.analyte import Analyte
 from clarity_ext.domain.container import Well
@@ -36,7 +38,7 @@ def fake_result_file(artifact_id=None, name=None, container_id=None, well_key=No
 
 
 def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_name=None,
-                 well_key=None, is_input=None, udf_map=None, **kwargs):
+                 well_key=None, is_input=None, is_control=False, udf_map=None, **kwargs):
     """
     Creates a fake Analyte domain object
 
@@ -56,8 +58,8 @@ def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_na
     if not udf_map:
         udf_map = DEFAULT_UDF_MAP['Analyte']
     analyte = Analyte(api_resource=api_resource, is_input=is_input,
-                      name=analyte_name, well=well, sample=sample,
-                      artifact_specific_udf_map=udf_map, **kwargs)
+                      name=analyte_name, well=well, is_control=is_control,
+                      sample=sample, artifact_specific_udf_map=udf_map, **kwargs)
     analyte.id = artifact_id
     analyte.generation_type = Artifact.PER_INPUT
     well.artifact = analyte


### PR DESCRIPTION
Add boolean is_control to analyte, in order to filter out control samples.
Update map creation for mapping between AliquotTransfers and Aliquot pairs.