### PR TITLE
Lims 731 cluster dilution

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -1,4 +1,6 @@
 from clarity_ext.dilution import DilutionScheme
+from clarity_ext.dilution import CONCENTRATION_REF_NGUL
+from clarity_ext.dilution import CONCENTRATION_REF_NM
 from clarity_ext import UnitConversion
 from clarity_ext.repository.file_repository import FileRepository
 from clarity_ext.utils import lazyprop
@@ -43,6 +45,7 @@ class ExtensionContext(object):
         self.current_user = current_user
         self.step_repo = step_repo
         self.response = None
+        self.dilution_scheme = None
 
     @staticmethod
     def create(step_id, cache=False):
@@ -65,10 +68,10 @@ class ExtensionContext(object):
     def udfs(self):
         return self.step_repo.all_udfs()
 
-    @lazyprop
-    def dilution_scheme(self):
+    def init_dilution_scheme(self, concentration_ref=None):
         # TODO: The caller needs to provide the robot
-        return DilutionScheme(self.artifact_service, "Hamilton")
+        self.dilution_scheme = DilutionScheme(
+            self.artifact_service, "Hamilton", concentration_ref=concentration_ref)
 
     @lazyprop
     def shared_files(self):

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -25,16 +25,29 @@ class TransferEndpoint(object):
         self.is_control = False
         if hasattr(aliquot, "is_control"):
             self.is_control = aliquot.is_control
-        self.requested_concentration = get_and_apply(
-            aliquot.__dict__, "target_concentration_ngul", None, float)
+        self.requested_concentration = self._referenced_requested_concentration(
+            aliquot, concentration_ref)
         self.requested_volume = get_and_apply(
-            aliquot.__dict__, "target_volume", None, float)
+            aliquot.__dict__, "requested_volume", None, float)
         self.well_index = None
         self.plate_pos = None
 
     def _referenced_concentration(self, aliquot=None, concentration_ref=None):
         if concentration_ref == CONCENTRATION_REF_NGUL:
             return aliquot.concentration_ngul
+        elif concentration_ref == CONCENTRATION_REF_NM:
+            return aliquot.concentration_nm
+        else:
+            raise NotImplementedError(
+                "Concentration ref {} not implemented".format(
+                    concentration_ref)
+            )
+
+    def _referenced_requested_concentration(self, aliquot=None, concentration_ref=None):
+        if concentration_ref == CONCENTRATION_REF_NGUL:
+            return aliquot.requested_concentration_ngul
+        elif concentration_ref == CONCENTRATION_REF_NM:
+            return aliquot.requested_concentration_nm
         else:
             raise NotImplementedError(
                 "Concentration ref {} not implemented".format(

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -5,6 +5,8 @@ from clarity_ext.utils import get_and_apply
 DILUTION_WASTE_VOLUME = 1
 ROBOT_MIN_VOLUME = 2
 PIPETTING_MAX_VOLUME = 50
+CONCENTRATION_REF_NGUL = 1
+CONCENTRATION_REF_NM = 2
 
 
 class TransferEndpoint(object):
@@ -13,11 +15,12 @@ class TransferEndpoint(object):
     """
     # TODO: Handle tube racks
 
-    def __init__(self, aliquot):
+    def __init__(self, aliquot, concentration_ref=None):
         self.sample_name = aliquot.name
         self.well = aliquot.well
         self.container = aliquot.container
-        self.concentration = aliquot.concentration_ngul
+        self.concentration = self._referenced_concentration(
+            aliquot=aliquot, concentration_ref=concentration_ref)
         self.volume = aliquot.volume
         self.is_control = False
         if hasattr(aliquot, "is_control"):
@@ -28,6 +31,15 @@ class TransferEndpoint(object):
             aliquot.__dict__, "target_volume", None, float)
         self.well_index = None
         self.plate_pos = None
+
+    def _referenced_concentration(self, aliquot=None, concentration_ref=None):
+        if concentration_ref == CONCENTRATION_REF_NGUL:
+            return aliquot.concentration_ngul
+        else:
+            raise NotImplementedError(
+                "Concentration ref {} not implemented".format(
+                    concentration_ref)
+            )
 
 
 class SingleTransfer(object):
@@ -176,7 +188,8 @@ class RobotDeckPositioner(object):
 class DilutionScheme(object):
     """Creates a dilution scheme, given input and output analytes."""
 
-    def __init__(self, artifact_service, robot_name, scale_up_low_volumes=True):
+    def __init__(self, artifact_service, robot_name, scale_up_low_volumes=True,
+                 concentration_ref=None):
         """
         Calculates all derived values needed in dilute driver file.
         """
@@ -186,7 +199,8 @@ class DilutionScheme(object):
         # TODO: Is it safe to just check for the container for the first output
         # analyte?
         container = pairs[0].output_artifact.container
-        all_transfers = self._create_transfers(pairs)
+        all_transfers = self._create_transfers(
+            pairs, concentration_ref=concentration_ref)
         self.transfers = list(t for t in all_transfers if t.is_control is False)
 
         self.aliquot_pair_by_transfer = self._map_pair_and_transfers(pairs=pairs)
@@ -198,12 +212,14 @@ class DilutionScheme(object):
         self.do_positioning()
         self.sort_transfers()
 
-    def _create_transfers(self, aliquot_pairs):
+    def _create_transfers(self, aliquot_pairs, concentration_ref=None):
         # TODO: handle tube racks
         transfers = []
         for pair in aliquot_pairs:
-            source_endpoint = TransferEndpoint(pair.input_artifact)
-            destination_endpoint = TransferEndpoint(pair.output_artifact)
+            source_endpoint = TransferEndpoint(
+                pair.input_artifact, concentration_ref=concentration_ref)
+            destination_endpoint = TransferEndpoint(
+                pair.output_artifact, concentration_ref=concentration_ref)
             transfers.append(SingleTransfer(
                 source_endpoint, destination_endpoint, pair_id=id(pair)))
         return transfers

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -17,13 +17,13 @@ class TransferEndpoint(object):
         self.sample_name = aliquot.name
         self.well = aliquot.well
         self.container = aliquot.container
-        self.concentration = aliquot.concentration
+        self.concentration = aliquot.concentration_ngul
         self.volume = aliquot.volume
         self.is_control = False
         if hasattr(aliquot, "is_control"):
             self.is_control = aliquot.is_control
         self.requested_concentration = get_and_apply(
-            aliquot.__dict__, "target_concentration", None, float)
+            aliquot.__dict__, "target_concentration_ngul", None, float)
         self.requested_volume = get_and_apply(
             aliquot.__dict__, "target_volume", None, float)
         self.well_index = None

--- a/clarity_ext/domain/aliquot.py
+++ b/clarity_ext/domain/aliquot.py
@@ -19,8 +19,8 @@ class Aliquot(Artifact):
             well.artifact = self
         else:
             self.container = None
-        self.concentration = get_and_apply(
-            kwargs, "concentration", None, float)
+        self.concentration_ngul = get_and_apply(
+            kwargs, "concentration_ngul", None, float)
         self.volume = get_and_apply(kwargs, "volume", None, float)
 
     @staticmethod

--- a/clarity_ext/domain/aliquot.py
+++ b/clarity_ext/domain/aliquot.py
@@ -19,9 +19,12 @@ class Aliquot(Artifact):
             well.artifact = self
         else:
             self.container = None
-        self.concentration_ngul = get_and_apply(
-            kwargs, "concentration_ngul", None, float)
-        self.volume = get_and_apply(kwargs, "volume", None, float)
+        self.requested_concentration_ngul = None
+        self.requested_concentration_nm = None
+        self.requested_volume = None
+        self.concentration_ngul = None
+        self.concentration_nm = None
+        self.volume = None
 
     @staticmethod
     def create_well_from_rest(resource, container_repo):

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -19,10 +19,17 @@ class Analyte(Aliquot):
         super(self.__class__, self).__init__(api_resource, is_input=is_input, id=id,
                                              samples=samples, name=name, well=well,
                                              artifact_specific_udf_map=artifact_specific_udf_map, **kwargs)
-        self.target_concentration_ngul = get_and_apply(
-            kwargs, "target_concentration_ngul", None, float)
-        self.target_volume = get_and_apply(
-            kwargs, "target_volume", None, float)
+        self.requested_concentration_ngul = get_and_apply(
+            kwargs, "requested_concentration_ngul", None, float)
+        self.requested_concentration_nm = get_and_apply(
+            kwargs, "requested_concentration_nm", None, float)
+        self.requested_volume = get_and_apply(
+            kwargs, "requested_volume", None, float)
+        self.concentration_ngul = get_and_apply(
+            kwargs, "concentration_ngul", None, float)
+        self.concentration_nm = get_and_apply(
+            kwargs, "concentration_nm", None, float)
+        self.volume = get_and_apply(kwargs, "volume", None, float)
         self.is_control = is_control
 
     def __repr__(self):

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -19,8 +19,8 @@ class Analyte(Aliquot):
         super(self.__class__, self).__init__(api_resource, is_input=is_input, id=id,
                                              samples=samples, name=name, well=well,
                                              artifact_specific_udf_map=artifact_specific_udf_map, **kwargs)
-        self.target_concentration = get_and_apply(
-            kwargs, "target_concentration", None, float)
+        self.target_concentration_ngul = get_and_apply(
+            kwargs, "target_concentration_ngul", None, float)
         self.target_volume = get_and_apply(
             kwargs, "target_volume", None, float)
         self.is_control = is_control

--- a/clarity_ext/extensions.py
+++ b/clarity_ext/extensions.py
@@ -343,7 +343,8 @@ class DriverFileExtension(GeneralFileExtension):
         results = list(validation_results)
         report = [repr(result) for result in results]
         if len(results) > 0:
-            self.logger.debug("Validation errors, len = {}".format(len(results)))
+            self.logger.debug(
+                "Validation errors, len = {}".format(len(results)))
             for r in results:
                 self.logger.debug("{}".format(r))
             raise ValueError("Validation errors: ".format(os.path.sep.join(report)))

--- a/clarity_ext/extensions.py
+++ b/clarity_ext/extensions.py
@@ -343,6 +343,9 @@ class DriverFileExtension(GeneralFileExtension):
         results = list(validation_results)
         report = [repr(result) for result in results]
         if len(results) > 0:
+            self.logger.debug("Validation errors, len = {}".format(len(results)))
+            for r in results:
+                self.logger.debug("{}".format(r))
             raise ValueError("Validation errors: ".format(os.path.sep.join(report)))
 
     @abstractmethod

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -181,13 +181,13 @@ different setups. TODO: Make the UDF map configurable in the settings for the cl
 """
 DEFAULT_UDF_MAP = {
     "Analyte": {
-        "concentration": "Conc. Current (ng/ul)",
-        "target_concentration": "Target Concentration",
-        "target_volume": "Target Volume",
+        "concentration_ngul": "Conc. Current (ng/ul)",
+        "target_concentration_ngul": "Target conc. (ng/ul)",
+        "target_volume": "Target vol. (ul)",
         "volume": "Current sample volume (ul)"
     },
     "ResultFile": {
-        "concentration": "Conc. Current (ng/ul)",
+        "concentration_ngul": "Conc. Current (ng/ul)",
         "volume": "Current sample volume (ul)"
     }
 }

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -182,8 +182,10 @@ different setups. TODO: Make the UDF map configurable in the settings for the cl
 DEFAULT_UDF_MAP = {
     "Analyte": {
         "concentration_ngul": "Conc. Current (ng/ul)",
-        "target_concentration_ngul": "Target conc. (ng/ul)",
-        "target_volume": "Target vol. (ul)",
+        "concentration_nm": "Conc. Current (nM)",
+        "requested_concentration_ngul": "Target conc. (ng/ul)",
+        "requested_concentration_nm": "Target conc. (nM)",
+        "requested_volume": "Target vol. (ul)",
         "volume": "Current sample volume (ul)"
     },
     "ResultFile": {

--- a/test/unit/clarity_ext/dilution/test_dilutions.py
+++ b/test/unit/clarity_ext/dilution/test_dilutions.py
@@ -1,6 +1,7 @@
 import unittest
 from mock import MagicMock
 from clarity_ext.dilution import DilutionScheme
+from clarity_ext.dilution import CONCENTRATION_REF_NGUL
 from test.unit.clarity_ext.helpers import fake_analyte, fake_result_file
 from test.unit.clarity_ext import helpers
 from clarity_ext.service import ArtifactService
@@ -12,11 +13,15 @@ class TestDilutionScheme(unittest.TestCase):
     based on fake data from the LIMS
     """
 
+    def _default_dilution_scheme(self, artifact_service):
+        return DilutionScheme(artifact_service=artifact_service, robot_name="Hamilton",
+                              scale_up_low_volumes=True, concentration_ref=CONCENTRATION_REF_NGUL)
+
     def test_dilution_scheme_hamilton_base(self):
         """Dilution scheme created by mocked analytes is correctly generated for Hamilton"""
         # Setup:
         svc = helpers.mock_two_containers_artifact_service()
-        dilution_scheme = DilutionScheme(svc, "Hamilton")
+        dilution_scheme = self._default_dilution_scheme(svc)
 
         expected = [
             ['art-name1', 36, 'DNA1', 14.9, 5.1, 34, 'END1'],
@@ -64,7 +69,7 @@ class TestDilutionScheme(unittest.TestCase):
             ]
 
         svc = helpers.mock_artifact_service(analyte_set_with_blank)
-        dilution_scheme = DilutionScheme(svc, 'Hamilton')
+        dilution_scheme = self._default_dilution_scheme(svc)
 
         mydict = analyte_set_with_blank()[3][0].__dict__
         print("control fake analyte: {}".format(mydict))
@@ -120,7 +125,7 @@ class TestDilutionScheme(unittest.TestCase):
             ]
 
         svc = helpers.mock_artifact_service(scaled_up_analyte_set)
-        dilution_scheme = DilutionScheme(svc, 'Hamilton')
+        dilution_scheme = self._default_dilution_scheme(svc)
 
         expected = [
             ['sample1', 10, 'DNA1', 2.0, 38.0, 10, 'END1'],
@@ -183,7 +188,7 @@ class TestDilutionScheme(unittest.TestCase):
             ]
 
         svc = helpers.mock_artifact_service(high_volume_analyte_set)
-        dilution_scheme = DilutionScheme(svc, "Hamilton")
+        dilution_scheme = self._default_dilution_scheme(svc)
         expected = [
             ['sample1', 10, 'DNA1', 50.0, 0, 10, 'END1'],
             ['sample2', 11, 'DNA1', 25.5, 0, 11, 'END1'],
@@ -239,7 +244,7 @@ class TestDilutionScheme(unittest.TestCase):
 
         svc = helpers.mock_artifact_service(analyte_result_file_set)
 
-        dilution_scheme = DilutionScheme(svc, "Hamilton")
+        dilution_scheme = self._default_dilution_scheme(svc)
 
         expected = [
             ['art-name1', 36, 'DNA1', 4],
@@ -293,7 +298,7 @@ class TestDilutionScheme(unittest.TestCase):
 
         svc = helpers.mock_artifact_service(invalid_analyte_set)
         dilution_scheme = DilutionScheme(
-            svc, "Hamilton", scale_up_low_volumes=False)
+            svc, "Hamilton", scale_up_low_volumes=False, concentration_ref=CONCENTRATION_REF_NGUL)
         actual = set(str(result) for result in dilution_scheme.validate())
         expected = set(["Error: Too low sample volume: cont-id1(D5)=>cont-id1(B5)"])
         self.assertEqual(expected, actual)
@@ -306,7 +311,7 @@ class TestDilutionScheme(unittest.TestCase):
                                   False, target_concentration_ngul=100, target_volume=20))
                     ]
         svc = helpers.mock_artifact_service(invalid_analyte_set)
-        dilution_scheme = DilutionScheme(svc, "Hamilton")
+        dilution_scheme = self._default_dilution_scheme(svc)
         actual = set(str(result) for result in dilution_scheme.validate())
         expected = set(["Error: Source volume is not set: cont-id1(D5)"])
         self.assertEqual(expected, actual)
@@ -319,7 +324,7 @@ class TestDilutionScheme(unittest.TestCase):
                                   False, target_concentration=100, target_volume=20))
                     ]
         svc = helpers.mock_artifact_service(invalid_analyte_set)
-        dilution_scheme = DilutionScheme(svc, "Hamilton")
+        dilution_scheme = self._default_dilution_scheme(svc)
         actual = set(str(result) for result in dilution_scheme.validate())
         expected = set(["Error: Source concentration not set: cont-id1(D5)"])
         self.assertEqual(expected, actual)
@@ -332,7 +337,7 @@ class TestDilutionScheme(unittest.TestCase):
                                   False, target_concentration=100, target_volume=20))
                     ]
         svc = helpers.mock_artifact_service(invalid_analyte_set)
-        dilution_scheme = DilutionScheme(svc, "Hamilton")
+        dilution_scheme = self._default_dilution_scheme(svc)
         actual = set(str(result) for result in dilution_scheme.validate())
         expected = set(["Error: Source concentration not set: cont-id1(D5)"])
         self.assertEqual(expected, actual)

--- a/test/unit/clarity_ext/dilution/test_dilutions.py
+++ b/test/unit/clarity_ext/dilution/test_dilutions.py
@@ -54,18 +54,18 @@ class TestDilutionScheme(unittest.TestCase):
                 (fake_analyte("cont1", "art1", "sample1", "sample1", "B:2", True,
                               concentration_ngul=100),
                  fake_analyte("cont2", "art2", "sample1", "sample1", "B:2", False,
-                              target_concentration_ngul=10, target_volume=20)),
+                              requested_concentration_ngul=10, requested_volume=20)),
                 (fake_analyte("cont1", "art7", "sample4", "sample4", "E:2", True, is_control=True),
                  fake_analyte("cont2", "art8", "sample4", "sample4", "E:2", False, is_control=True,
-                              target_concentration_ngul=10, target_volume=20)),
+                              requested_concentration_ngul=10, requested_volume=20)),
                 (fake_analyte("cont1", "art3", "sample2", "sample2", "C:2", True,
                               concentration_ngul=100),
                  fake_analyte("cont2", "art4", "sample2", "sample2", "C:2", False,
-                              target_concentration_ngul=10, target_volume=20)),
+                              requested_concentration_ngul=10, requested_volume=20)),
                 (fake_analyte("cont1", "art5", "sample3", "sample3", "D:2", True,
                               concentration_ngul=100),
                  fake_analyte("cont2", "art6", "sample3", "sample3", "D:2", False,
-                              target_concentration_ngul=10, target_volume=20)),
+                              requested_concentration_ngul=10, requested_volume=20)),
             ]
 
         svc = helpers.mock_artifact_service(analyte_set_with_blank)
@@ -109,19 +109,19 @@ class TestDilutionScheme(unittest.TestCase):
                 (fake_analyte("cont1", "art1", "sample1", "sample1", "B:2", True,
                               concentration_ngul=200),
                  fake_analyte("cont2", "art2", "sample1", "sample1", "B:2", False,
-                              target_concentration_ngul=10, target_volume=20)),
+                              requested_concentration_ngul=10, requested_volume=20)),
                 (fake_analyte("cont1", "art3", "sample2", "sample2", "C:2", True,
                               concentration_ngul=10),
                  fake_analyte("cont2", "art4", "sample2", "sample2", "C:2", False,
-                              target_concentration_ngul=10, target_volume=1)),
+                              requested_concentration_ngul=10, requested_volume=1)),
                 (fake_analyte("cont1", "art5", "sample3", "sample3", "D:2", True,
                               concentration_ngul=20),
                  fake_analyte("cont2", "art6", "sample3", "sample3", "D:2", False,
-                              target_concentration_ngul=40, target_volume=0.5)),
+                              requested_concentration_ngul=40, requested_volume=0.5)),
                 (fake_analyte("cont1", "art7", "sample4", "sample4", "E:2", True,
                               concentration_ngul=80),
                  fake_analyte("cont2", "art8", "sample4", "sample4", "E:2", False,
-                              target_concentration_ngul=40, target_volume=10)),
+                              requested_concentration_ngul=40, requested_volume=10)),
             ]
 
         svc = helpers.mock_artifact_service(scaled_up_analyte_set)
@@ -168,23 +168,23 @@ class TestDilutionScheme(unittest.TestCase):
                 (fake_analyte("cont-id1", "art1-id1", "sample1", "sample1", "B:2", True,
                               concentration_ngul=10),
                  fake_analyte("cont-id1", "art1-id2", "sample1", "sample1", "B:2", False,
-                              target_concentration_ngul=50, target_volume=10)),
+                              requested_concentration_ngul=50, requested_volume=10)),
                 (fake_analyte("cont-id1", "art1-id3", "sample2", "sample2", "C:2", True,
                               concentration_ngul=10),
                  fake_analyte("cont-id1", "art1-id4", "sample2", "sample2", "C:2", False,
-                              target_concentration_ngul=10, target_volume=51)),
+                              requested_concentration_ngul=10, requested_volume=51)),
                 (fake_analyte("cont-id1", "art1-id5", "sample3", "sample3", "D:2", True,
                               concentration_ngul=100),
                  fake_analyte("cont-id1", "art1-id6", "sample3", "sample3", "D:2", False,
-                              target_concentration_ngul=2, target_volume=50)),
+                              requested_concentration_ngul=2, requested_volume=50)),
                 (fake_analyte("cont-id1", "art1-id7", "sample4", "sample4", "E:2", True,
                               concentration_ngul=100),
                  fake_analyte("cont-id1", "art1-id8", "sample4", "sample4", "E:2", False,
-                              target_concentration_ngul=10, target_volume=150)),
+                              requested_concentration_ngul=10, requested_volume=150)),
                 (fake_analyte("cont-id1", "art1-id9", "sample5", "sample5", "F:2", True,
                               concentration_ngul=100),
                  fake_analyte("cont-id1", "art1-id10", "sample5", "sample5", "F:2", False,
-                              target_concentration_ngul=60, target_volume=150)),
+                              requested_concentration_ngul=60, requested_volume=150)),
             ]
 
         svc = helpers.mock_artifact_service(high_volume_analyte_set)
@@ -273,7 +273,7 @@ class TestDilutionScheme(unittest.TestCase):
                 (fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5", True,
                               concentration=100, volume=20),
                  fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "B:5", False,
-                              target_concentration=1000, target_volume=20))
+                              requested_concentration_ngul=1000, requested_volume=20))
             ]
 
             return inputs, outputs
@@ -293,7 +293,7 @@ class TestDilutionScheme(unittest.TestCase):
             return [(fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5",
                                   True, concentration_ngul=100, volume=20),
                      fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "B:5",
-                                  False, target_concentration=2, target_volume=20))
+                                  False, requested_concentration_ngul=2, requested_volume=20))
                     ]
 
         svc = helpers.mock_artifact_service(invalid_analyte_set)
@@ -308,7 +308,7 @@ class TestDilutionScheme(unittest.TestCase):
             return [(fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5",
                                   True, concentration_ngul=100),
                      fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "B:5",
-                                  False, target_concentration_ngul=100, target_volume=20))
+                                  False, requested_concentration_ngul=100, requested_volume=20))
                     ]
         svc = helpers.mock_artifact_service(invalid_analyte_set)
         dilution_scheme = self._default_dilution_scheme(svc)
@@ -321,7 +321,7 @@ class TestDilutionScheme(unittest.TestCase):
             return [(fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5",
                                   True, volume=20),
                      fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "B:5",
-                                  False, target_concentration=100, target_volume=20))
+                                  False, requested_concentration_ngul=100, requested_volume=20))
                     ]
         svc = helpers.mock_artifact_service(invalid_analyte_set)
         dilution_scheme = self._default_dilution_scheme(svc)
@@ -334,7 +334,7 @@ class TestDilutionScheme(unittest.TestCase):
             return [(fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5",
                                   True, volume=20, concentration=0),
                      fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "B:5",
-                                  False, target_concentration=100, target_volume=20))
+                                  False, requested_concentration_ngul=100, requested_volume=20))
                     ]
         svc = helpers.mock_artifact_service(invalid_analyte_set)
         dilution_scheme = self._default_dilution_scheme(svc)

--- a/test/unit/clarity_ext/dilution/test_dilutions.py
+++ b/test/unit/clarity_ext/dilution/test_dilutions.py
@@ -47,20 +47,20 @@ class TestDilutionScheme(unittest.TestCase):
         def analyte_set_with_blank():
             return [
                 (fake_analyte("cont1", "art1", "sample1", "sample1", "B:2", True,
-                              concentration=100),
+                              concentration_ngul=100),
                  fake_analyte("cont2", "art2", "sample1", "sample1", "B:2", False,
-                              target_concentration=10, target_volume=20)),
+                              target_concentration_ngul=10, target_volume=20)),
                 (fake_analyte("cont1", "art7", "sample4", "sample4", "E:2", True, is_control=True),
                  fake_analyte("cont2", "art8", "sample4", "sample4", "E:2", False, is_control=True,
-                              target_concentration=10, target_volume=20)),
+                              target_concentration_ngul=10, target_volume=20)),
                 (fake_analyte("cont1", "art3", "sample2", "sample2", "C:2", True,
-                              concentration=100),
+                              concentration_ngul=100),
                  fake_analyte("cont2", "art4", "sample2", "sample2", "C:2", False,
-                              target_concentration=10, target_volume=20)),
+                              target_concentration_ngul=10, target_volume=20)),
                 (fake_analyte("cont1", "art5", "sample3", "sample3", "D:2", True,
-                              concentration=100),
+                              concentration_ngul=100),
                  fake_analyte("cont2", "art6", "sample3", "sample3", "D:2", False,
-                              target_concentration=10, target_volume=20)),
+                              target_concentration_ngul=10, target_volume=20)),
             ]
 
         svc = helpers.mock_artifact_service(analyte_set_with_blank)
@@ -102,21 +102,21 @@ class TestDilutionScheme(unittest.TestCase):
         def scaled_up_analyte_set():
             return [
                 (fake_analyte("cont1", "art1", "sample1", "sample1", "B:2", True,
-                              concentration=200),
+                              concentration_ngul=200),
                  fake_analyte("cont2", "art2", "sample1", "sample1", "B:2", False,
-                              target_concentration=10, target_volume=20)),
+                              target_concentration_ngul=10, target_volume=20)),
                 (fake_analyte("cont1", "art3", "sample2", "sample2", "C:2", True,
-                              concentration=10),
+                              concentration_ngul=10),
                  fake_analyte("cont2", "art4", "sample2", "sample2", "C:2", False,
-                              target_concentration=10, target_volume=1)),
+                              target_concentration_ngul=10, target_volume=1)),
                 (fake_analyte("cont1", "art5", "sample3", "sample3", "D:2", True,
-                              concentration=20),
+                              concentration_ngul=20),
                  fake_analyte("cont2", "art6", "sample3", "sample3", "D:2", False,
-                              target_concentration=40, target_volume=0.5)),
+                              target_concentration_ngul=40, target_volume=0.5)),
                 (fake_analyte("cont1", "art7", "sample4", "sample4", "E:2", True,
-                              concentration=80),
+                              concentration_ngul=80),
                  fake_analyte("cont2", "art8", "sample4", "sample4", "E:2", False,
-                              target_concentration=40, target_volume=10)),
+                              target_concentration_ngul=40, target_volume=10)),
             ]
 
         svc = helpers.mock_artifact_service(scaled_up_analyte_set)
@@ -161,25 +161,25 @@ class TestDilutionScheme(unittest.TestCase):
         def high_volume_analyte_set():
             return [
                 (fake_analyte("cont-id1", "art1-id1", "sample1", "sample1", "B:2", True,
-                              concentration=10),
+                              concentration_ngul=10),
                  fake_analyte("cont-id1", "art1-id2", "sample1", "sample1", "B:2", False,
-                              target_concentration=50, target_volume=10)),
+                              target_concentration_ngul=50, target_volume=10)),
                 (fake_analyte("cont-id1", "art1-id3", "sample2", "sample2", "C:2", True,
-                              concentration=10),
+                              concentration_ngul=10),
                  fake_analyte("cont-id1", "art1-id4", "sample2", "sample2", "C:2", False,
-                              target_concentration=10, target_volume=51)),
+                              target_concentration_ngul=10, target_volume=51)),
                 (fake_analyte("cont-id1", "art1-id5", "sample3", "sample3", "D:2", True,
-                              concentration=100),
+                              concentration_ngul=100),
                  fake_analyte("cont-id1", "art1-id6", "sample3", "sample3", "D:2", False,
-                              target_concentration=2, target_volume=50)),
+                              target_concentration_ngul=2, target_volume=50)),
                 (fake_analyte("cont-id1", "art1-id7", "sample4", "sample4", "E:2", True,
-                              concentration=100),
+                              concentration_ngul=100),
                  fake_analyte("cont-id1", "art1-id8", "sample4", "sample4", "E:2", False,
-                              target_concentration=10, target_volume=150)),
+                              target_concentration_ngul=10, target_volume=150)),
                 (fake_analyte("cont-id1", "art1-id9", "sample5", "sample5", "F:2", True,
-                              concentration=100),
+                              concentration_ngul=100),
                  fake_analyte("cont-id1", "art1-id10", "sample5", "sample5", "F:2", False,
-                              target_concentration=60, target_volume=150)),
+                              target_concentration_ngul=60, target_volume=150)),
             ]
 
         svc = helpers.mock_artifact_service(high_volume_analyte_set)
@@ -286,7 +286,7 @@ class TestDilutionScheme(unittest.TestCase):
     def test_dilution_scheme_too_low_sample_volume(self):
         def invalid_analyte_set():
             return [(fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5",
-                                  True, concentration=100, volume=20),
+                                  True, concentration_ngul=100, volume=20),
                      fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "B:5",
                                   False, target_concentration=2, target_volume=20))
                     ]
@@ -301,9 +301,9 @@ class TestDilutionScheme(unittest.TestCase):
     def test_dilution_scheme_source_volume_not_set(self):
         def invalid_analyte_set():
             return [(fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5",
-                                  True, concentration=100),
+                                  True, concentration_ngul=100),
                      fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "B:5",
-                                  False, target_concentration=100, target_volume=20))
+                                  False, target_concentration_ngul=100, target_volume=20))
                     ]
         svc = helpers.mock_artifact_service(invalid_analyte_set)
         dilution_scheme = DilutionScheme(svc, "Hamilton")

--- a/test/unit/clarity_ext/dilution/test_update_fields.py
+++ b/test/unit/clarity_ext/dilution/test_update_fields.py
@@ -60,18 +60,18 @@ def analyte_set_with_blank():
     return [
         (fake_analyte("cont1", "art7", "sample4", "sample4", "E:2", True, is_control=True),
          fake_analyte("cont2", "art8", "sample4", "sample4", "E:2", False, is_control=True,
-                      target_concentration=100, target_volume=20)),
+                      requested_concentration=100, requested_volume=20)),
         (fake_analyte("cont1", "art1", "sample1", "sample1", "B:2", True,
                       concentration=100, volume=30),
          fake_analyte("cont2", "art2", "sample1", "sample1", "B:2", False,
-                      target_concentration=100, target_volume=20)),
+                      requested_concentration=100, requested_volume=20)),
         (fake_analyte("cont1", "art3", "sample2", "sample2", "C:2", True,
                       concentration=100, volume=40),
          fake_analyte("cont2", "art4", "sample2", "sample2", "C:2", False,
-                      target_concentration=100, target_volume=20)),
+                      requested_concentration=100, requested_volume=20)),
         (fake_analyte("cont1", "art5", "sample3", "sample3", "D:2", True,
                       concentration=100, volume=50),
          fake_analyte("cont2", "art6", "sample3", "sample3", "D:2", False,
-                      target_concentration=100, target_volume=20)),
+                      requested_concentration=100, requested_volume=20)),
     ]
 

--- a/test/unit/clarity_ext/dilution/test_update_fields.py
+++ b/test/unit/clarity_ext/dilution/test_update_fields.py
@@ -2,6 +2,7 @@ import unittest
 from clarity_ext.dilution import DILUTION_WASTE_VOLUME
 from mock import MagicMock
 from clarity_ext.dilution import DilutionScheme
+from clarity_ext.dilution import CONCENTRATION_REF_NGUL
 from test.unit.clarity_ext import helpers
 from test.unit.clarity_ext.helpers import fake_analyte
 
@@ -10,7 +11,8 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
 
     def setUp(self):
         svc = helpers.mock_artifact_service(analyte_set_with_blank)
-        self.dilution_scheme = DilutionScheme(svc, "Hamilton")
+        self.dilution_scheme = DilutionScheme(
+            svc, "Hamilton", concentration_ref=CONCENTRATION_REF_NGUL)
 
         analyte_pair_by_dilute = self.dilution_scheme.aliquot_pair_by_transfer
         for dilute in self.dilution_scheme.transfers:

--- a/test/unit/clarity_ext/domain/test_artifact.py
+++ b/test/unit/clarity_ext/domain/test_artifact.py
@@ -175,10 +175,8 @@ class TestArtifact(unittest.TestCase):
     def test_create_from_rest_result_file(self):
         api_resource = mock_artifact_resource(
             resouce_id="art1", sample_name="sample1", well_position="B:2")
-        api_resource.udf = {"conc from udf": 10}
-        udf_map = {
-            "ResultFile": {"concentration_ngul": "conc from udf"}
-        }
+        api_resource.udf = {}
+        udf_map = {"ResultFile": {}}
         container_repo = mock_container_repo(container_id="cont1")
 
         result_file = ResultFile.create_from_rest_resource(
@@ -198,8 +196,6 @@ class TestArtifact(unittest.TestCase):
 
         print("artifact: {}".format(result_file))
 
-        self.assertEqual(expected_result_file.concentration_ngul,
-                         result_file.concentration_ngul)
         self.assertEqual(expected_result_file.id, result_file.id)
         self.assertEqual(expected_result_file.name, result_file.name)
         self.assertEqual(result_file.well.__repr__(),
@@ -210,10 +206,8 @@ class TestArtifact(unittest.TestCase):
     def test_create_result_file_with_no_container(self):
         api_resource = mock_artifact_resource(
             resouce_id="art1", sample_name="sample1")
-        api_resource.udf = {"conc from udf": 10}
-        udf_map = {
-            "ResultFile": {"concentration_ngul": "conc from udf"}
-        }
+        api_resource.udf = {}
+        udf_map = {"ResultFile": {}}
         container_repo = mock_container_repo(container_id=None)
 
         result_file = ResultFile.create_from_rest_resource(
@@ -222,7 +216,7 @@ class TestArtifact(unittest.TestCase):
 
         expected_result_file = fake_result_file(
             artifact_id="art1", container_id=None, name="sample1", well_key="B:2",
-            is_input=False, udf_map=udf_map, concentration_ngul=10)
+            is_input=False, udf_map={}, concentration_ngul=10)
 
         print("result_file:")
         for key in result_file.__dict__:
@@ -233,8 +227,6 @@ class TestArtifact(unittest.TestCase):
 
         print("artifact: {}".format(result_file))
 
-        self.assertEqual(expected_result_file.concentration_ngul,
-                         result_file.concentration_ngul)
         self.assertEqual(expected_result_file.id, result_file.id)
         self.assertEqual(expected_result_file.name, result_file.name)
         self.assertEqual(result_file.well.__repr__(),

--- a/test/unit/clarity_ext/domain/test_artifact.py
+++ b/test/unit/clarity_ext/domain/test_artifact.py
@@ -112,7 +112,7 @@ class TestArtifact(unittest.TestCase):
         api_resource.id = "art1"
         api_resource.name = "sample1"
         udf_map = {
-            "Analyte": {"concentration": "conc from udf"}
+            "Analyte": {"concentration_ngul": "conc from udf"}
         }
         container_repo = MagicMock()
         container = fake_container("cont1")
@@ -124,7 +124,7 @@ class TestArtifact(unittest.TestCase):
 
         expected_analyte = fake_analyte(container_id="cont1", artifact_id="art1", sample_id="sample1",
                                         analyte_name="sample1", well_key="B:2", is_input=True,
-                                        concentration=10)
+                                        concentration_ngul=10)
 
         print("analyte:")
         for key in analyte.__dict__:
@@ -133,7 +133,7 @@ class TestArtifact(unittest.TestCase):
         for key in expected_analyte.__dict__:
             print("{}\t{}".format(key, expected_analyte.__dict__[key]))
 
-        self.assertEqual(expected_analyte.concentration, analyte.concentration)
+        self.assertEqual(expected_analyte.concentration_ngul, analyte.concentration_ngul)
         self.assertEqual(expected_analyte.id, analyte.id)
         self.assertEqual(expected_analyte.name, analyte.name)
         self.assertEqual(expected_analyte.well.__repr__(),
@@ -176,7 +176,7 @@ class TestArtifact(unittest.TestCase):
             resouce_id="art1", sample_name="sample1", well_position="B:2")
         api_resource.udf = {"conc from udf": 10}
         udf_map = {
-            "ResultFile": {"concentration": "conc from udf"}
+            "ResultFile": {"concentration_ngul": "conc from udf"}
         }
         container_repo = mock_container_repo(container_id="cont1")
 
@@ -186,7 +186,7 @@ class TestArtifact(unittest.TestCase):
 
         expected_result_file = fake_result_file(
             artifact_id="art1", container_id="cont1", name="sample1", well_key="B:2",
-            is_input=False, udf_map=udf_map, concentration=10)
+            is_input=False, udf_map=udf_map, concentration_ngul=10)
 
         print("result_file:")
         for key in result_file.__dict__:
@@ -197,8 +197,8 @@ class TestArtifact(unittest.TestCase):
 
         print("artifact: {}".format(result_file))
 
-        self.assertEqual(expected_result_file.concentration,
-                         result_file.concentration)
+        self.assertEqual(expected_result_file.concentration_ngul,
+                         result_file.concentration_ngul)
         self.assertEqual(expected_result_file.id, result_file.id)
         self.assertEqual(expected_result_file.name, result_file.name)
         self.assertEqual(result_file.well.__repr__(),
@@ -211,7 +211,7 @@ class TestArtifact(unittest.TestCase):
             resouce_id="art1", sample_name="sample1")
         api_resource.udf = {"conc from udf": 10}
         udf_map = {
-            "ResultFile": {"concentration": "conc from udf"}
+            "ResultFile": {"concentration_ngul": "conc from udf"}
         }
         container_repo = mock_container_repo(container_id=None)
 
@@ -221,7 +221,7 @@ class TestArtifact(unittest.TestCase):
 
         expected_result_file = fake_result_file(
             artifact_id="art1", container_id=None, name="sample1", well_key="B:2",
-            is_input=False, udf_map=udf_map, concentration=10)
+            is_input=False, udf_map=udf_map, concentration_ngul=10)
 
         print("result_file:")
         for key in result_file.__dict__:
@@ -232,8 +232,8 @@ class TestArtifact(unittest.TestCase):
 
         print("artifact: {}".format(result_file))
 
-        self.assertEqual(expected_result_file.concentration,
-                         result_file.concentration)
+        self.assertEqual(expected_result_file.concentration_ngul,
+                         result_file.concentration_ngul)
         self.assertEqual(expected_result_file.id, result_file.id)
         self.assertEqual(expected_result_file.name, result_file.name)
         self.assertEqual(result_file.well.__repr__(),

--- a/test/unit/clarity_ext/domain/test_artifact.py
+++ b/test/unit/clarity_ext/domain/test_artifact.py
@@ -133,7 +133,8 @@ class TestArtifact(unittest.TestCase):
         for key in expected_analyte.__dict__:
             print("{}\t{}".format(key, expected_analyte.__dict__[key]))
 
-        self.assertEqual(expected_analyte.concentration_ngul, analyte.concentration_ngul)
+        self.assertEqual(expected_analyte.concentration_ngul,
+                         analyte.concentration_ngul)
         self.assertEqual(expected_analyte.id, analyte.id)
         self.assertEqual(expected_analyte.name, analyte.name)
         self.assertEqual(expected_analyte.well.__repr__(),

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -138,18 +138,18 @@ def two_containers_artifact_set():
         (fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5", True,
                       concentration_ngul=134, volume=30),
          fake_analyte("cont-id3", "art-id1", "sample1", "art-name1", "B:5", False,
-                      target_concentration_ngul=100, target_volume=20)),
+                      requested_concentration_ngul=100, requested_volume=20)),
         (fake_analyte("cont-id2", "art-id2", "sample2", "art-name2", "A:5", True,
                       concentration_ngul=134, volume=40),
          fake_analyte("cont-id4", "art-id2", "sample2", "art-name2", "A:3", False,
-                      target_concentration_ngul=100, target_volume=20)),
+                      requested_concentration_ngul=100, requested_volume=20)),
         (fake_analyte("cont-id2", "art-id3", "sample3", "art-name3", "B:7", True,
                       concentration_ngul=134, volume=50),
          fake_analyte("cont-id3", "art-id3", "sample3", "art-name3", "D:6", False,
-                      target_concentration_ngul=100, target_volume=20)),
+                      requested_concentration_ngul=100, requested_volume=20)),
         (fake_analyte("cont-id2", "art-id4", "sample4", "art-name4", "E:12", True,
                       concentration_ngul=134, volume=60),
          fake_analyte("cont-id4", "art-id4", "sample4", "art-name4", "E:9", False,
-                      target_concentration_ngul=100, target_volume=20))
+                      requested_concentration_ngul=100, requested_volume=20))
     ]
     return ret

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -136,20 +136,20 @@ def two_containers_artifact_set():
     """
     ret = [
         (fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5", True,
-                      concentration=134, volume=30),
+                      concentration_ngul=134, volume=30),
          fake_analyte("cont-id3", "art-id1", "sample1", "art-name1", "B:5", False,
-                      target_concentration=100, target_volume=20)),
+                      target_concentration_ngul=100, target_volume=20)),
         (fake_analyte("cont-id2", "art-id2", "sample2", "art-name2", "A:5", True,
-                      concentration=134, volume=40),
+                      concentration_ngul=134, volume=40),
          fake_analyte("cont-id4", "art-id2", "sample2", "art-name2", "A:3", False,
-                      target_concentration=100, target_volume=20)),
+                      target_concentration_ngul=100, target_volume=20)),
         (fake_analyte("cont-id2", "art-id3", "sample3", "art-name3", "B:7", True,
-                      concentration=134, volume=50),
+                      concentration_ngul=134, volume=50),
          fake_analyte("cont-id3", "art-id3", "sample3", "art-name3", "D:6", False,
-                      target_concentration=100, target_volume=20)),
+                      target_concentration_ngul=100, target_volume=20)),
         (fake_analyte("cont-id2", "art-id4", "sample4", "art-name4", "E:12", True,
-                      concentration=134, volume=60),
+                      concentration_ngul=134, volume=60),
          fake_analyte("cont-id4", "art-id4", "sample4", "art-name4", "E:9", False,
-                      target_concentration=100, target_volume=20))
+                      target_concentration_ngul=100, target_volume=20))
     ]
     return ret


### PR DESCRIPTION
Adjust clarity-ext so that it can make dilutions with concentration units ng/ul or nM. 

Import new udfs to analyte, refering to conc unit nM. Since calculations in DilutionScheme is independent of concentration unit, have a working variable for concentration, that can be initiated to either conc (ng/ul) or conc (nM). 

DilutionScheme now requires input argument concentration reference.