### PR TITLE
Lims 725 warning popup

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -1,6 +1,4 @@
 from clarity_ext.dilution import DilutionScheme
-from clarity_ext.dilution import CONCENTRATION_REF_NGUL
-from clarity_ext.dilution import CONCENTRATION_REF_NM
 from clarity_ext import UnitConversion
 from clarity_ext.repository.file_repository import FileRepository
 from clarity_ext.utils import lazyprop
@@ -9,6 +7,7 @@ from clarity_ext.service import ArtifactService, FileService, StepLoggerService
 from clarity_ext.repository import StepRepository
 from clarity_ext import utils
 from clarity_ext.driverfile import OSService
+from clarity_ext.service.validation_service import ERRORS_AND_WARNING_ENTRY_NAME
 
 
 class ExtensionContext(object):
@@ -69,10 +68,16 @@ class ExtensionContext(object):
         return self.step_repo.all_udfs()
 
     def init_dilution_scheme(self, concentration_ref=None, include_blanks=False):
+        file_list = [file for file in self.shared_files if file.name ==
+                     ERRORS_AND_WARNING_ENTRY_NAME]
+        if not len(file_list) == 1:
+            raise ValueError("This step is not configured with the shared file entry for {}".format(
+                ERRORS_AND_WARNING_ENTRY_NAME))
+        error_log_artifact = file_list[0]
         # TODO: The caller needs to provide the robot
         self.dilution_scheme = DilutionScheme(
             self.artifact_service, "Hamilton", concentration_ref=concentration_ref,
-            include_blanks=include_blanks)
+            include_blanks=include_blanks, error_log_artifact=error_log_artifact)
 
     @lazyprop
     def shared_files(self):

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -204,11 +204,12 @@ class DilutionScheme(object):
     """Creates a dilution scheme, given input and output analytes."""
 
     def __init__(self, artifact_service, robot_name, scale_up_low_volumes=True,
-                 concentration_ref=None, include_blanks=False):
+                 concentration_ref=None, include_blanks=False, error_log_artifact=None):
         """
         Calculates all derived values needed in dilute driver file.
         """
         self.scale_up_low_volumes = scale_up_low_volumes
+        self.error_log_artifact = error_log_artifact
         pairs = artifact_service.all_aliquot_pairs()
 
         # TODO: Is it safe to just check for the container for the first output

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -1,6 +1,6 @@
-from clarity_ext.domain.validation import ValidationException, ValidationType
 import copy
 from clarity_ext.utils import get_and_apply
+from itertools import groupby
 
 DILUTION_WASTE_VOLUME = 1
 ROBOT_MIN_VOLUME = 2
@@ -25,6 +25,7 @@ class TransferEndpoint(object):
         self.is_control = False
         if hasattr(aliquot, "is_control"):
             self.is_control = aliquot.is_control
+        self.is_from_original = aliquot.is_from_original
         self.requested_concentration = self._referenced_requested_concentration(
             aliquot, concentration_ref)
         self.requested_volume = get_and_apply(
@@ -63,6 +64,7 @@ class SingleTransfer(object):
         self.pair_id = pair_id
         self.sample_name = source_endpoint.sample_name
         self.is_control = source_endpoint.is_control
+        self.is_source_from_original = source_endpoint.is_from_original
 
         self.source_endpoint = source_endpoint
         self.destination_endpoint = destination_endpoint
@@ -225,6 +227,18 @@ class DilutionScheme(object):
         self.split_up_high_volume_rows()
         self.do_positioning()
         self.sort_transfers()
+        self.grouped_transfers = list(self._grouped_transfers())
+
+    def _grouped_transfers(self):
+        """
+        Sometimes a sample transfer from source A to destination B is
+        split up on several rows, due to the max pipetting volume of 50 ul.
+        :return: An iterable group of transfers for a common destination well.
+        """
+        for key, transfer_group in groupby(
+                self.transfers, key=lambda t: "{}{}".format(
+                    t.target_container, t.target_well.position)):
+            yield list(transfer_group)
 
     def _filtered_transfers(self, all_transfers, include_blanks):
         if include_blanks:
@@ -377,30 +391,6 @@ class DilutionScheme(object):
                 transfer.target_well)
             transfer.target_plate_pos = self.robot_deck_positioner \
                 .target_plate_position_map[transfer.target_container.id]
-
-    def validate(self):
-        """
-        Yields validation errors or warnings
-
-        TODO: These validation errors should not be in clarity-ext (implementation specific)
-        """
-        def pos_str(transfer):
-            return "{}=>{}".format(transfer.source_well, transfer.target_well)
-
-        for transfer in self.transfers:
-            if not transfer.source_initial_volume:
-                yield ValidationException("Source volume is not set: {}".format(transfer.source_well))
-            if not transfer.source_concentration:
-                yield ValidationException("Source concentration not set: {}".format(transfer.source_well))
-            else:
-                if transfer.sample_volume < 2:
-                    yield ValidationException("Too low sample volume: " + pos_str(transfer))
-                elif transfer.sample_volume > 50:
-                    yield ValidationException("Too high sample volume: " + pos_str(transfer))
-                if transfer.has_to_evaporate:
-                    yield ValidationException("Sample has to be evaporated: " + pos_str(transfer), ValidationType.WARNING)
-                if transfer.buffer_volume > 50:
-                    yield ValidationException("Too high buffer volume: " + pos_str(transfer))
 
     def __str__(self):
         return "<DilutionScheme positioner={}>".format(self.robot_deck_positioner)

--- a/clarity_ext/domain/aliquot.py
+++ b/clarity_ext/domain/aliquot.py
@@ -25,6 +25,7 @@ class Aliquot(Artifact):
         self.concentration_ngul = None
         self.concentration_nm = None
         self.volume = None
+        self.is_from_original = False
 
     @staticmethod
     def create_well_from_rest(resource, container_repo):

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -12,7 +12,8 @@ class Analyte(Aliquot):
     """
 
     def __init__(self, api_resource, is_input, id=None, samples=None, name=None, well=None,
-                 is_control=False, artifact_specific_udf_map=None, **kwargs):
+                 is_control=False, artifact_specific_udf_map=None, is_from_original=None,
+                 **kwargs):
         """
         Creates an analyte
         """
@@ -31,6 +32,7 @@ class Analyte(Aliquot):
             kwargs, "concentration_nm", None, float)
         self.volume = get_and_apply(kwargs, "volume", None, float)
         self.is_control = is_control
+        self.is_output_from_previous = is_from_original
 
     def __repr__(self):
         return "{} ({})".format(self.name, self.id)
@@ -59,10 +61,13 @@ class Analyte(Aliquot):
         # TODO: This code principally belongs to the genologics layer, but 'control-type' does not exist there
         if resource.root.find("control-type") is not None:
             is_control = True
+        # TODO: A better way to decide if analyte is output of a previous step?
+        is_from_original = (resource.id.find("2-") != 0)
         analyte = Analyte(api_resource=resource, is_input=is_input, id=resource.id,
                           samples=samples, name=resource.name,
                           well=well, is_control=is_control,
-                          artifact_specific_udf_map=analyte_udf_map, **kwargs)
+                          artifact_specific_udf_map=analyte_udf_map,
+                          is_from_original=is_from_original, **kwargs)
         analyte.api_resource = resource
         analyte.reagent_labels = resource.reagent_labels
 

--- a/clarity_ext/domain/shared_result_file.py
+++ b/clarity_ext/domain/shared_result_file.py
@@ -24,6 +24,7 @@ class SharedResultFile(Artifact):
 
     def updated_rest_resource(self, original_rest_resource, updated_fields):
         _updated_rest_resource = \
-            super(self.__class__, self).updated_rest_resource(original_rest_resource, updated_fields)
+            super(self.__class__, self).updated_rest_resource(
+                original_rest_resource, updated_fields)
 
         return _updated_rest_resource, self.assigner.consume()

--- a/clarity_ext/domain/shared_result_file.py
+++ b/clarity_ext/domain/shared_result_file.py
@@ -1,16 +1,29 @@
 from clarity_ext.domain.artifact import Artifact
+from clarity_ext.utils import get_and_apply
 
 
 class SharedResultFile(Artifact):
 
-    def __init__(self, api_resource=None, id=None, name=None, artifact_specific_udf_map=None):
+    def __init__(self, api_resource=None, id=None, name=None, artifact_specific_udf_map=None,
+                 **kwargs):
         super(SharedResultFile, self).__init__(
             api_resource=api_resource, id=id, name=name,
             artifact_specific_udf_map=artifact_specific_udf_map)
+        self.has_errors = bool(get_and_apply(kwargs, "has_errors", 0, int))
 
     @staticmethod
     def create_from_rest_resource(api_resource, udf_map=None):
-        shared_result_file_udf_map = udf_map.get("SharedResultFile")
+        shared_result_file_udf_map = udf_map.get("SharedResultFile", dict())
         name = api_resource.name
+        specific_udf_map = udf_map["SharedResultFile"]
+        kwargs = {key: api_resource.udf.get(
+            specific_udf_map[key], None) for key in specific_udf_map}
+
         return SharedResultFile(api_resource=api_resource, id=api_resource.id, name=name,
-                                artifact_specific_udf_map=shared_result_file_udf_map)
+                                artifact_specific_udf_map=shared_result_file_udf_map, **kwargs)
+
+    def updated_rest_resource(self, original_rest_resource, updated_fields):
+        _updated_rest_resource = \
+            super(self.__class__, self).updated_rest_resource(original_rest_resource, updated_fields)
+
+        return _updated_rest_resource, self.assigner.consume()

--- a/clarity_ext/extensions.py
+++ b/clarity_ext/extensions.py
@@ -15,6 +15,7 @@ from clarity_ext.repository import StepRepository
 from clarity_ext.service import ArtifactService
 from test.integration.integration_test_service import IntegrationTest
 from clarity_ext.repository.step_repository import DEFAULT_UDF_MAP
+from clarity_ext.service.validation_service import ValidationService
 
 
 # Defines all classes that are expected to be extended. These are
@@ -305,6 +306,11 @@ class GeneralExtension(object):
         self.context = context
         self.logger = logging.getLogger(self.__class__.__module__)
         self.response = None
+        self.validation_service = ValidationService(
+            context=context, logger=self.logger)
+
+    def handle_validation(self, validation_results):
+        return self.validation_service.handle_validation(validation_results)
 
     @abstractmethod
     def integration_tests(self):
@@ -336,18 +342,6 @@ class DriverFileExtension(GeneralFileExtension):
     def shared_file(self):
         """Returns the name of the shared file that should include the newly generated file"""
         return "Sample List"
-
-    def handle_validation(self, validation_results):
-        # TODO: Move this code to a validation service
-        # TODO: Communicate this to the LIMS rather than throwing an exception
-        results = list(validation_results)
-        report = [repr(result) for result in results]
-        if len(results) > 0:
-            self.logger.debug(
-                "Validation errors, len = {}".format(len(results)))
-            for r in results:
-                self.logger.debug("{}".format(r))
-            raise ValueError("Validation errors: ".format(os.path.sep.join(report)))
 
     @abstractmethod
     def content(self):
@@ -388,4 +382,3 @@ class SampleSheetExtension(DriverFileExtension):
 class ExtensionTest(object):
     def __init__(self, pid):
         self.pid = pid
-

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -153,9 +153,9 @@ class StepRepository(object):
         response = []
         for artifact in artifacts:
             updated_fields = self._retrieve_updated_fields(artifact)
-            original_analyte_from_rest = artifact.api_resource
+            original_artifact_from_rest = artifact.api_resource
             updated_rest_resource, single_response = \
-                artifact.updated_rest_resource(original_analyte_from_rest, updated_fields)
+                artifact.updated_rest_resource(original_artifact_from_rest, updated_fields)
             response.append(single_response)
             update_queue.append(updated_rest_resource)
 

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -155,7 +155,8 @@ class StepRepository(object):
             updated_fields = self._retrieve_updated_fields(artifact)
             original_artifact_from_rest = artifact.api_resource
             updated_rest_resource, single_response = \
-                artifact.updated_rest_resource(original_artifact_from_rest, updated_fields)
+                artifact.updated_rest_resource(
+                    original_artifact_from_rest, updated_fields)
             response.append(single_response)
             update_queue.append(updated_rest_resource)
 

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -191,5 +191,8 @@ DEFAULT_UDF_MAP = {
     "ResultFile": {
         "concentration_ngul": "Conc. Current (ng/ul)",
         "volume": "Current sample volume (ul)"
+    },
+    "SharedResultFile": {
+        "has_errors": "Has errors2",
     }
 }

--- a/clarity_ext/service/step_logger_service.py
+++ b/clarity_ext/service/step_logger_service.py
@@ -7,7 +7,8 @@ class StepLoggerService:
     """
     Provides support for logging to shared files in a step.
     """
-    def __init__(self, step_logger_name, file_service, raise_if_not_found=False, append=True):
+
+    def __init__(self, step_logger_name, file_service, raise_if_not_found=False, append=True, extension="log"):
         self.core_logger = logging.getLogger(__name__)
         self.step_logger_name = step_logger_name
         self.file_service = file_service
@@ -17,7 +18,7 @@ class StepLoggerService:
         self.NEW_LINE = "\r\n"
         try:
             mode = "ab" if append else "wb"
-            self.step_log = self.file_service.local_shared_file(step_logger_name, extension="log",
+            self.step_log = self.file_service.local_shared_file(step_logger_name, extension=extension,
                                                                 mode=mode, modify_attached=True)
         except SharedFileNotFound:
             if raise_if_not_found:

--- a/clarity_ext/service/validation_service.py
+++ b/clarity_ext/service/validation_service.py
@@ -1,0 +1,39 @@
+from clarity_ext.service.step_logger_service import StepLoggerService
+from clarity_ext.domain.validation import ValidationType
+
+# A step using the validation service must be configured with the
+# shared file entry 'Errors and warnings'
+ERRORS_AND_WARNING_ENTRY_NAME = "Errors_and_warnings"
+
+
+class ValidationService:
+
+    def __init__(self, context=None, logger=None, step_logger_name=ERRORS_AND_WARNING_ENTRY_NAME):
+        self.logger = logger
+        self.has_errors = False
+        self.has_warnings = False
+        if context:
+            self.step_logger_service = StepLoggerService(step_logger_name=step_logger_name,
+                                                         file_service=context.file_service,
+                                                         raise_if_not_found=False, append=False,
+                                                         extension="txt")
+
+    def handle_validation(self, validation_results):
+        results = list(validation_results)
+        self.has_errors = any(r.type == ValidationType.ERROR for r in results)
+        self.has_warnings = any(
+            r.type == ValidationType.WARNING for r in results)
+        results = sorted(results, key=lambda r: r.type)
+        if len(results) > 0:
+            self._log_debug(
+                "Validation errors, len = {}".format(len(results)))
+            for r in results:
+                msg_row = "{}".format(r)
+                self.step_logger_service.log(msg_row)
+                self._log_debug("{}".format(msg_row))
+
+        return self.has_errors, self.has_warnings
+
+    def _log_debug(self, msg):
+        if self.logger is not None:
+            self.logger.debug(msg)

--- a/test/integration/integration_test_service.py
+++ b/test/integration/integration_test_service.py
@@ -3,31 +3,64 @@ from itertools import chain
 
 
 class IntegrationTest:
-    def __init__(self, pid=None, run_argument_dict=None, update_matrix=None):
+    """
+    Option to update a context to a specified state before the integration test is run.
+    Context state is updated by either update_matrix_by_limsid, or update_matrix_by_artnames,
+    or both.
+
+    Format for update_matrix_by_limsid:
+    [
+        ('limsid', 'field name', field value),
+        ...
+    ]
+
+    Format for update_matrix_by_artnames:
+    [
+        ('input/output ref', 'artifact name', 'field name', field value),
+        ...
+    ]
+    with input/output ref either of:
+        'input'
+        'output'
+    """
+
+    def __init__(self, pid=None, run_argument_dict=None, update_matrix_by_limsid=None,
+                 update_matrix_by_artnames=None):
         self.run_argument_dict = {}
         if pid:
             self.run_argument_dict = {"pid": pid}
         if run_argument_dict:
             self.run_argument_dict.update(run_argument_dict)
 
-        if update_matrix:
-            self.preparer = IntegrationTestPrepare(update_matrix)
+        if not update_matrix_by_limsid:
+            update_matrix_by_limsid = []
+
+        self.preparer = None
+        self.preparer = IntegrationTestPrepare(
+            update_matrix_by_limsid=update_matrix_by_limsid, update_matrix_by_artnames=update_matrix_by_artnames)
 
     def pid(self):
         return self.run_argument_dict["pid"]
 
 
 class IntegrationTestPrepare:
-    def __init__(self, update_matrix):
-        self.update_matrix = update_matrix
+
+    def __init__(self, update_matrix_by_limsid=None, update_matrix_by_artnames=None):
+        self._update_matrix_by_limsid = update_matrix_by_limsid
+        self._update_matrix_by_artnames = update_matrix_by_artnames
+        self._update_matrix = None
+        # artifact service is not defined in outer scope until the prepare
+        # method is called
+        self.artifact_service = None
 
     def prepare(self, artifact_service):
+        self.artifact_service = artifact_service
         artifacts = chain(artifact_service.all_input_artifacts(),
                           artifact_service.all_output_artifacts())
         artifact_dict = {artifact.id: artifact for artifact in artifacts}
         self._check_artifacts_exists(artifact_dict)
         update_queue = []
-        for update_row in self.update_matrix:
+        for update_row in self._get_update_matrix():
             art_id = update_row[0]
             udf_name = update_row[1]
             value = update_row[2]
@@ -38,10 +71,44 @@ class IntegrationTestPrepare:
         artifact_service.update_artifacts(update_queue)
 
     def _check_artifacts_exists(self, artifact_dict):
-        for update_row in self.update_matrix:
+        for update_row in self._get_update_matrix():
             art_id = update_row[0]
             if art_id not in artifact_dict:
-                raise ArtifactsNotFound("Given lims-id is not matching artifacts in step ({})".format(art_id))
+                raise ArtifactsNotFound(
+                    "Given lims-id is not matching artifacts in step ({})".format(art_id))
+
+    def _get_update_matrix(self):
+        if not self._update_matrix:
+            matrix = self._transform_update_matrix_by_artnames(
+                update_matrix_by_artnames=self._update_matrix_by_artnames)
+            if not matrix:
+                matrix = []
+            if not self._update_matrix_by_limsid:
+                self._update_matrix_by_limsid = []
+            self._update_matrix = self._update_matrix_by_limsid + matrix
+        return self._update_matrix
+
+    def _transform_update_matrix_by_artnames(self, update_matrix_by_artnames=None):
+        if not update_matrix_by_artnames:
+            return
+        update_matrix_by_limsid = []
+        for row in update_matrix_by_artnames:
+            artifact = self._fetch_artifact(
+                input_output_ref=row[0], artifact_name=row[1])
+            new_row = ("{}".format(artifact.id), row[2], row[3])
+            update_matrix_by_limsid.append(new_row)
+        return update_matrix_by_limsid
+
+    def _fetch_artifact(self, input_output_ref=None, artifact_name=None):
+            if input_output_ref == 'input':
+                artifacts = self.artifact_service.all_input_artifacts()
+            elif input_output_ref == 'output':
+                artifacts = self.artifact_service.all_output_artifacts()
+            else:
+                raise ValueError(
+                    "Not recognized key word in matrix, should be either ''input'' or ''output'', {}".format(row[0]))
+            arts = [art for art in artifacts if art.name == artifact_name]
+            return arts[0]
 
 
 class ArtifactsNotFound(Exception):

--- a/test/unit/clarity_ext/domain/test_artifact.py
+++ b/test/unit/clarity_ext/domain/test_artifact.py
@@ -236,10 +236,13 @@ class TestArtifact(unittest.TestCase):
         api_resource = MagicMock()
         api_resource.id = "id1"
         api_resource.name = "name1"
+        api_resource.udf = {"Has errors": 1}
+        udf_map = {"SharedResultFile": {"has_errors": "Has errors"}}
 
         shared_result_file = SharedResultFile.create_from_rest_resource(
-            api_resource=api_resource, udf_map=dict())
+            api_resource=api_resource, udf_map=udf_map)
         expected_shared_result_file = fake_shared_result_file("id1", "name1")
         self.assertEqual(expected_shared_result_file.id, shared_result_file.id)
         self.assertEqual(expected_shared_result_file.name,
                          shared_result_file.name)
+        self.assertEqual(True, shared_result_file.has_errors)

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -38,7 +38,8 @@ def fake_result_file(artifact_id=None, name=None, container_id=None, well_key=No
 
 
 def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_name=None,
-                 well_key=None, is_input=None, is_control=False, udf_map=None, **kwargs):
+                 well_key=None, is_input=None, is_control=False, udf_map=None, api_resource = None,
+                 **kwargs):
     """
     Creates a fake Analyte domain object
 
@@ -54,7 +55,6 @@ def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_na
     pos = ContainerPosition.create(well_key)
     well = Well(pos, container)
     sample = Sample(sample_id, sample_id, MagicMock())
-    api_resource = None
     if not udf_map:
         udf_map = DEFAULT_UDF_MAP['Analyte']
     analyte = Analyte(api_resource=api_resource, is_input=is_input,

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -38,7 +38,7 @@ def fake_result_file(artifact_id=None, name=None, container_id=None, well_key=No
 
 
 def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_name=None,
-                 well_key=None, is_input=None, is_control=False, udf_map=None, api_resource = None,
+                 well_key=None, is_input=None, is_control=False, udf_map=None, api_resource=None,
                  **kwargs):
     """
     Creates a fake Analyte domain object

--- a/test/unit/clarity_ext/service/test_validation_service.py
+++ b/test/unit/clarity_ext/service/test_validation_service.py
@@ -1,0 +1,49 @@
+import unittest
+from mock import MagicMock
+from mock import call
+import logging
+from clarity_ext.extensions import ValidationService
+from clarity_ext.domain.validation import ValidationException
+from clarity_ext.domain.validation import ValidationType
+from clarity_ext.context import ExtensionContext
+
+
+class TestValidationService(unittest.TestCase):
+
+    def setUp(self):
+        self.logger = logging.getLogger(self.__class__.__module__)
+
+    def instantiate_context(self):
+        session = MagicMock()
+        artifact_svc = MagicMock()
+        file_svc = MagicMock()
+        current_user = MagicMock()
+        step_logger_svc = MagicMock()
+        return ExtensionContext(session, artifact_svc, file_svc, current_user, step_logger_svc, None)
+
+    def test_validation_logging(self):
+        context = self.instantiate_context()
+        validation_service = ValidationService(
+            context=context, logger=self.logger)
+        step_logger_service = MagicMock()
+        step_logger_service.log = MagicMock()
+        validation_service.step_logger_service = step_logger_service
+        error_exception = ValidationException(
+            "Error message", validation_type=ValidationType.ERROR)
+        warning_exception = ValidationException(
+            "Warning message", validation_type=ValidationType.WARNING)
+        validation_service.handle_validation([error_exception])
+
+        validation_service.step_logger_service.log.assert_called_once_with(
+            "{}".format(error_exception))
+        self.assertEqual(validation_service.has_errors, True)
+        self.assertEqual(validation_service.has_warnings, False)
+
+        validation_service.handle_validation(
+                [error_exception, warning_exception])
+        calls = [call("{}".format(error_exception)),
+                 call("{}".format(warning_exception))]
+        validation_service.step_logger_service.log.assert_has_calls(
+            calls, any_order=False)
+        self.assertEqual(validation_service.has_errors, True)
+        self.assertEqual(validation_service.has_warnings, True)

--- a/test/unit/clarity_ext/test_step_repository.py
+++ b/test/unit/clarity_ext/test_step_repository.py
@@ -4,14 +4,16 @@ import test.unit.clarity_ext.helpers
 from test.unit.clarity_ext.helpers import fake_analyte
 from mock import MagicMock
 
+
 class TestStepRepository(unittest.TestCase):
+
     def test_update_nothing(self):
         session = MagicMock()
         session.api = MagicMock()
         udf_map = {
-                       "concentration_ngul": "conc",
-                       "requested_concentration_ngul": "rconc",
-                   }
+            "concentration_ngul": "conc",
+            "requested_concentration_ngul": "rconc",
+        }
         step_repo = StepRepository(session=session, udf_map=udf_map)
         artifacts = artifact_set(udf_map=udf_map)
         artifacts = list(artifacts[0])
@@ -23,9 +25,9 @@ class TestStepRepository(unittest.TestCase):
         session = MagicMock()
         session.api = MagicMock()
         udf_map = {
-                       "concentration_ngul": "conc",
-                       "requested_concentration_ngul": "rconc",
-                   }
+            "concentration_ngul": "conc",
+            "requested_concentration_ngul": "rconc",
+        }
         step_repo = StepRepository(session=session, udf_map=udf_map)
         artifacts = artifact_set(udf_map=udf_map)
         artifacts = list(artifacts[0])
@@ -38,7 +40,7 @@ class TestStepRepository(unittest.TestCase):
 
 def artifact_set(udf_map=None):
     api_resource = MagicMock()
-    api_resource.udf = {"conc": 100,}
+    api_resource.udf = {"conc": 100, }
     return [
         (fake_analyte("cont1", "art1", "sample1", "sample1", "B:2", True, udf_map=udf_map,
                       api_resource=api_resource, concentration_ngul=100, volume=30),

--- a/test/unit/clarity_ext/test_step_repository.py
+++ b/test/unit/clarity_ext/test_step_repository.py
@@ -1,0 +1,47 @@
+from clarity_ext.repository.step_repository import StepRepository
+import unittest
+import test.unit.clarity_ext.helpers
+from test.unit.clarity_ext.helpers import fake_analyte
+from mock import MagicMock
+
+class TestStepRepository(unittest.TestCase):
+    def test_update_nothing(self):
+        session = MagicMock()
+        session.api = MagicMock()
+        udf_map = {
+                       "concentration_ngul": "conc",
+                       "requested_concentration_ngul": "rconc",
+                   }
+        step_repo = StepRepository(session=session, udf_map=udf_map)
+        artifacts = artifact_set(udf_map=udf_map)
+        artifacts = list(artifacts[0])
+        step_repo._add_to_orig_state_cache(artifact_set(udf_map=udf_map))
+        response = step_repo.update_artifacts(artifacts)
+        self.assertEqual([], response)
+
+    def test_update_one_field(self):
+        session = MagicMock()
+        session.api = MagicMock()
+        udf_map = {
+                       "concentration_ngul": "conc",
+                       "requested_concentration_ngul": "rconc",
+                   }
+        step_repo = StepRepository(session=session, udf_map=udf_map)
+        artifacts = artifact_set(udf_map=udf_map)
+        artifacts = list(artifacts[0])
+        step_repo._add_to_orig_state_cache(artifact_set(udf_map=udf_map))
+        updated_artifact = artifacts[0]
+        updated_artifact.concentration_ngul = 99
+        response = step_repo.update_artifacts(artifacts)
+        self.assertEqual([('Analyte', 'art1', 'conc', '99')], response)
+
+
+def artifact_set(udf_map=None):
+    api_resource = MagicMock()
+    api_resource.udf = {"conc": 100,}
+    return [
+        (fake_analyte("cont1", "art1", "sample1", "sample1", "B:2", True, udf_map=udf_map,
+                      api_resource=api_resource, concentration_ngul=100, volume=30),
+         fake_analyte("cont2", "art2", "sample1", "sample1", "B:2", False, udf_map=udf_map,
+                      api_resource=api_resource, requested_concentration_ngul=100, requested_volume=20)),
+    ]

--- a/test/unit/clarity_ext/utility/test_integration_test_service.py
+++ b/test/unit/clarity_ext/utility/test_integration_test_service.py
@@ -17,7 +17,7 @@ class TestIntegrationTestService(unittest.TestCase):
         test = IntegrationTest(run_argument_dict=run_args)
         self.assertEqual(test.pid(), "pid1")
 
-    def test_run_prepare(self):
+    def test_run_prepare_by_limsid_ref(self):
         artifact_set = [(fake_analyte("cont1", "art1", "sample1", "art1", "A:1", True, volume=1),
                          fake_analyte("cont1", "art2", "sample1", "art2", "A:1", False)),
                         (fake_analyte("cont1", "art3", "sample2", "art3", "B:1", True, volume=0),
@@ -30,16 +30,47 @@ class TestIntegrationTestService(unittest.TestCase):
                          ("art3", "Current sample volume (ul)", 50)]
 
         artifact_service = helpers.mock_artifact_service(pre_test_artifact_set)
-        test = IntegrationTest(pid="pid1", update_matrix=update_matrix)
+        artifact_service.update_artifacts = MagicMock()
+        test = IntegrationTest(
+            pid="pid1", update_matrix_by_limsid=update_matrix)
         self.assertIsNotNone(test.preparer)
 
-        artifact_service.update_artifacts = Mock()
         test.preparer.prepare(artifact_service)
 
         art1 = pre_test_artifact_set()[0][0]
         art3 = pre_test_artifact_set()[1][0]
         expected_updated_queue = [art1, art3]
 
-        artifact_service.update_artifacts.assert_called_with(expected_updated_queue)
+        artifact_service.update_artifacts.assert_called_with(
+            expected_updated_queue)
         self.assertEqual(art1.volume, 50)
         self.assertEqual(art3.volume, 50)
+
+    def test_run_prepare_by_artname_ref(self):
+        artifact_set = [(fake_analyte("cont1", "art1", "sample1", "analyte_name1", "A:1", True, volume=1),
+                         fake_analyte("cont1", "art2", "sample1", "analyte_name2", "A:1", False)),
+                        (fake_analyte("cont1", "art3", "sample2", "analyte_name3", "B:1", True, volume=0),
+                         fake_analyte("cont1", "art4", "sample2", "analyte_name4", "B:1", False))]
+
+        def pre_test_artifact_set():
+            return artifact_set
+
+        update_matrix = [("input", "analyte_name1", "Current sample volume (ul)", 50),
+                         ("output", "analyte_name4", "Current sample volume (ul)", 50)]
+
+        artifact_service = helpers.mock_artifact_service(pre_test_artifact_set)
+        artifact_service.update_artifacts = MagicMock()
+        test = IntegrationTest(
+            pid="pid1", update_matrix_by_artnames=update_matrix)
+        self.assertIsNotNone(test.preparer)
+
+        test.preparer.prepare(artifact_service)
+
+        art1 = pre_test_artifact_set()[0][0]
+        art4 = pre_test_artifact_set()[1][1]
+        expected_updated_queue = [art1, art4]
+
+        artifact_service.update_artifacts.assert_called_with(
+            expected_updated_queue)
+        self.assertEqual(art1.volume, 50)
+        self.assertEqual(art4.volume, 50)


### PR DESCRIPTION
Break out validation code from DriverFileExtension to the new class
ValidationService. Move validation code in DilutionScheme to snpseq
scripts.

Errors and warnings generated from the validation are exported to a file with entry name Errors_and_warning. The script with the validation code are typically triggered from a button, to give the user the opportunity to change parameters until she is satisfied, clicking the button several times if needed. 

There is a check if the user tries to go to the next step with unresolved errors. For this, there is a udf 'Has errors2' associated with the artifact for the Shared result file 'Errors_and_warnings', which is updated when needed each time the button-script is run.
