### PR TITLE
Add logic for supress printing out labels

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -8,9 +8,10 @@ from clarity_ext.repository import StepRepository
 from clarity_ext import utils
 from clarity_ext.driverfile import OSService
 from clarity_ext.service.validation_service import ERRORS_AND_WARNING_ENTRY_NAME
+from clarity_ext.domain.udf import Udf
 
 
-class ExtensionContext(object):
+class ExtensionContext(Udf):
     """
     Defines context objects for extensions.
 
@@ -33,6 +34,8 @@ class ExtensionContext(object):
         :param step_repo: The repository for the current step
         :param cache: Set to True to use the cache folder (.cache) for downloaded files
         """
+        super(ExtensionContext, self).__init__(
+            api_resource=session.current_step, id=session.current_step_id)
         self.session = session
         self.cache = cache
         self.logger = step_logger_service

--- a/clarity_ext/domain/artifact.py
+++ b/clarity_ext/domain/artifact.py
@@ -1,11 +1,8 @@
-import re
+from clarity_ext.domain.udf import Udf
 from clarity_ext.domain.common import DomainObjectMixin
-from clarity_ext.utils import lazyprop
-from clarity_ext.domain.common import AssignLogger
-from clarity_ext.unit_conversion import UnitConversion
 
 
-class Artifact(DomainObjectMixin):
+class Artifact(Udf):
     """
     Represents any input or output artifact from the Clarity server, e.g. an Analyte
     or a ResultFile.
@@ -18,88 +15,11 @@ class Artifact(DomainObjectMixin):
     OUTPUT_TYPE_SHARED_RESULT_FILE = 3
 
     def __init__(self, api_resource=None, id=None, name=None, artifact_specific_udf_map=None):
-        self.id = id
+        super(Artifact, self).__init__(api_resource=api_resource, id=id,
+                                       entity_specific_udf_map=artifact_specific_udf_map)
         self.is_input = None  # Set to true if this is an input artifact
         self.generation_type = None  # Set to PER_INPUT or PER_ALL_INPUTS if applicable
         self.name = name
-        if artifact_specific_udf_map:
-            self.udf_map = artifact_specific_udf_map
-        else:
-            self.udf_map = dict()
-        self.assigner = AssignLogger(self)
-        self.api_resource = api_resource
-        if api_resource:
-            attributes, self.udfs_to_attributes = self._create_automap(api_resource.udf)
-            self.__dict__.update(attributes)
-
-    @lazyprop
-    def udf_backward_map(self):
-        return {self.udf_map[key]: key for key in self.udf_map}
-
-    def reset_assigner(self):
-        self.assigner = AssignLogger(self)
-
-    def set_udf(self, name, value, from_unit=None, to_unit=None):
-        if from_unit:
-            units = UnitConversion()
-            value = units.convert(value, from_unit, to_unit)
-        if name in self.udf_backward_map:
-            # Assign existing instance variable
-            # Log for assignment of instance variables are handled in
-            # step_repository.commit()
-            self.__dict__[self.udf_backward_map[name]] = value
-        else:
-            # There is no mapped instance variable for this udf.
-            # Log the assignment right away
-            self.api_resource.udf[name] = self.assigner.register_assign(name, value)
-
-    def get_udf(self, name):
-        return self.api_resource.udf[name]
-
-    def updated_rest_resource(self, original_rest_resource, updated_fields):
-        """
-        :param original_rest_resource: The rest resource in the state as in the api cache
-        :return: An updated rest resource according to changes in this instance of Analyte
-        """
-        _updated_rest_resource = original_rest_resource
-
-        # Update udf values
-        values_by_udf_names = {self.udf_map[key]: self.__dict__[key]
-                               for key in self.udf_map if key in updated_fields}
-        # Retrieve fields that are updated, only these field should be included in the rest update
-        for key in values_by_udf_names:
-            value = values_by_udf_names[key]
-            _updated_rest_resource.udf[key] = self.assigner.register_assign(key, value)
-
-        return _updated_rest_resource
-
-    def commit(self):
-        self.api_resource.put()
-
-    def _create_automap(self, original_udfs):
-        """
-        Given a dictionary of UDFs, returns a new dictionary that uses Python naming conventions instead.
-
-        Also returns a dictionary mapping from the original UDF name back to the attribute name, which can
-        be used to synchronize the two if needed.
-        """
-        attributes = dict()
-        udfs_to_attributes = dict()  # A dictionary that matches from Python attributes back to the api resource UDFs.
-        for key, value in original_udfs.items():
-            attrib_name = self._automap_name(key)
-            attributes[attrib_name] = value
-            udfs_to_attributes[key] = attrib_name
-        return attributes, udfs_to_attributes
-
-    def _automap_name(self, original_udf_name):
-        """
-        Maps a UDF name from Clarity to one that matches Python naming conventions
-
-        Example: 'Fragment Lower (bp)' => 'fragment_lower_bp'
-        """
-        new_name = original_udf_name.lower().replace(" ", "_")
-        new_name = re.sub("\W+", "", new_name)  # Get rid of all non-alphanumeric characters
-        return "udf_{}".format(new_name)
 
 
 class ArtifactPair(DomainObjectMixin):

--- a/clarity_ext/domain/udf.py
+++ b/clarity_ext/domain/udf.py
@@ -1,0 +1,99 @@
+import re
+from clarity_ext.domain.common import DomainObjectMixin
+from clarity_ext.utils import lazyprop
+from clarity_ext.domain.common import AssignLogger
+from clarity_ext.unit_conversion import UnitConversion
+
+
+class Udf(DomainObjectMixin):
+    """
+    Represents an entity having udfs
+    """
+
+    def __init__(self, api_resource=None, id=None, entity_specific_udf_map=None):
+        self.id = id
+        if entity_specific_udf_map:
+            self.udf_map = entity_specific_udf_map
+        else:
+            self.udf_map = dict()
+        self.assigner = AssignLogger(self)
+        self.api_resource = api_resource
+        if api_resource:
+            attributes, self.udfs_to_attributes = self._create_automap(
+                api_resource.udf)
+            self.__dict__.update(attributes)
+
+    @lazyprop
+    def udf_backward_map(self):
+        return {self.udf_map[key]: key for key in self.udf_map}
+
+    def reset_assigner(self):
+        self.assigner = AssignLogger(self)
+
+    def set_udf(self, name, value, from_unit=None, to_unit=None):
+        if from_unit:
+            units = UnitConversion()
+            value = units.convert(value, from_unit, to_unit)
+        if name in self.udf_backward_map:
+            # Assign existing instance variable
+            # Log for assignment of instance variables are handled in
+            # step_repository.commit()
+            self.__dict__[self.udf_backward_map[name]] = value
+        else:
+            # There is no mapped instance variable for this udf.
+            # Log the assignment right away
+            self.api_resource.udf[
+                name] = self.assigner.register_assign(name, value)
+
+    def get_udf(self, name):
+        return self.api_resource.udf[name]
+
+    def updated_rest_resource(self, original_rest_resource, updated_fields):
+        """
+        :param original_rest_resource: The rest resource in the state as in the api cache
+        :return: An updated rest resource according to changes in this instance of Analyte
+        """
+        _updated_rest_resource = original_rest_resource
+
+        # Update udf values
+        values_by_udf_names = {self.udf_map[key]: self.__dict__[key]
+                               for key in self.udf_map if key in updated_fields}
+        # Retrieve fields that are updated, only these field should be included
+        # in the rest update
+        for key in values_by_udf_names:
+            value = values_by_udf_names[key]
+            _updated_rest_resource.udf[
+                key] = self.assigner.register_assign(key, value)
+
+        return _updated_rest_resource
+
+    def commit(self):
+        self.api_resource.put()
+
+    def _create_automap(self, original_udfs):
+        """
+        Given a dictionary of UDFs, returns a new dictionary that uses Python naming conventions instead.
+
+        Also returns a dictionary mapping from the original UDF name back to the attribute name, which can
+        be used to synchronize the two if needed.
+        """
+        attributes = dict()
+        # A dictionary that matches from Python attributes back to the api
+        # resource UDFs.
+        udfs_to_attributes = dict()
+        for key, value in original_udfs.items():
+            attrib_name = self._automap_name(key)
+            attributes[attrib_name] = value
+            udfs_to_attributes[key] = attrib_name
+        return attributes, udfs_to_attributes
+
+    def _automap_name(self, original_udf_name):
+        """
+        Maps a UDF name from Clarity to one that matches Python naming conventions
+
+        Example: 'Fragment Lower (bp)' => 'fragment_lower_bp'
+        """
+        new_name = original_udf_name.lower().replace(" ", "_")
+        # Get rid of all non-alphanumeric characters
+        new_name = re.sub("\W+", "", new_name)
+        return "udf_{}".format(new_name)

--- a/test/unit/clarity_ext/test_context.py
+++ b/test/unit/clarity_ext/test_context.py
@@ -36,3 +36,19 @@ class TestContext(unittest.TestCase):
         # Fetching a single output_container should throw in this case
         self.assertRaises(ValueError, input_should_raise)
         self.assertRaises(ValueError, output_should_raise)
+
+    def test_udf(self):
+        artifact_svc = helpers.mock_two_containers_artifact_service()
+        file_svc = MagicMock()
+        current_user = MagicMock()
+        step_logger_svc = MagicMock()
+        api_resource = MagicMock()
+        api_resource.udf = {"myudf": "udf_value"}
+        session = MagicMock()
+        session.current_step = api_resource
+        context = ExtensionContext(
+            session, artifact_svc, file_svc, current_user, step_logger_svc, None)
+        self.assertEqual(context.get_udf("myudf"), "udf_value")
+
+        context.set_udf("myudf", "another_value")
+        self.assertEqual(context.get_udf("myudf"), "another_value")


### PR DESCRIPTION
At dilution steps (dna dilution + lib dilution), there is now a udf 'Print labels', that control if printing out labels or not, with default value 'no'. This udf should be shown during the validation period only.

In this pull request, make possible to get and set udfs for ExtensionContext. Previously, udfs could only be handled for Artifacts. 

Create the new base class Udf, and let both ExtensionContext and Artifact inherit from it. The code for udf handling is taken from the Artifact class.
