### PR TITLE
Make pooled dilutions

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -70,7 +70,8 @@ class ExtensionContext(Udf):
     def udfs(self):
         return self.step_repo.all_udfs()
 
-    def init_dilution_scheme(self, concentration_ref=None, include_blanks=False):
+    def init_dilution_scheme(self, concentration_ref=None, include_blanks=False,
+                             volume_calc_method=None, make_pools=False):
         file_list = [file for file in self.shared_files if file.name ==
                      ERRORS_AND_WARNING_ENTRY_NAME]
         if not len(file_list) == 1:
@@ -78,9 +79,11 @@ class ExtensionContext(Udf):
                 ERRORS_AND_WARNING_ENTRY_NAME))
         error_log_artifact = file_list[0]
         # TODO: The caller needs to provide the robot
-        self.dilution_scheme = DilutionScheme(
-            self.artifact_service, "Hamilton", concentration_ref=concentration_ref,
-            include_blanks=include_blanks, error_log_artifact=error_log_artifact)
+        self.dilution_scheme = DilutionScheme.create(
+            artifact_service=self.artifact_service, robot_name="Hamilton",
+            concentration_ref=concentration_ref, include_blanks=include_blanks,
+            error_log_artifact=error_log_artifact,
+            volume_calc_method=volume_calc_method, make_pools=make_pools)
 
     @lazyprop
     def shared_files(self):

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -1,12 +1,14 @@
 import copy
 from clarity_ext.utils import get_and_apply
 from itertools import groupby
+from clarity_ext.dilution_strategies import *
 
 DILUTION_WASTE_VOLUME = 1
-ROBOT_MIN_VOLUME = 2
 PIPETTING_MAX_VOLUME = 50
 CONCENTRATION_REF_NGUL = 1
 CONCENTRATION_REF_NM = 2
+VOLUME_CALC_FIXED = 1
+VOLUME_CALC_BY_CONC = 2
 
 
 class TransferEndpoint(object):
@@ -204,12 +206,14 @@ class DilutionScheme(object):
     """Creates a dilution scheme, given input and output analytes."""
 
     def __init__(self, artifact_service, robot_name, scale_up_low_volumes=True,
-                 concentration_ref=None, include_blanks=False, error_log_artifact=None):
+                 concentration_ref=None, include_blanks=False, error_log_artifact=None,
+                 volume_calc_strategy=None):
         """
         Calculates all derived values needed in dilute driver file.
         """
         self.scale_up_low_volumes = scale_up_low_volumes
         self.error_log_artifact = error_log_artifact
+        self.volume_calc_strategy = volume_calc_strategy
         pairs = artifact_service.all_aliquot_pairs()
 
         # TODO: Is it safe to just check for the container for the first output
@@ -265,25 +269,8 @@ class DilutionScheme(object):
 
     def calculate_transfer_volumes(self):
         # Handle volumes etc.
-        for transfer in self.transfers:
-            try:
-                transfer.sample_volume = \
-                    transfer.requested_concentration * transfer.requested_volume / \
-                    transfer.source_concentration
-                transfer.buffer_volume = \
-                    max(transfer.requested_volume - transfer.sample_volume, 0)
-                transfer.has_to_evaporate = \
-                    (transfer.requested_volume - transfer.sample_volume) < 0
-                if self.scale_up_low_volumes and transfer.sample_volume < ROBOT_MIN_VOLUME:
-                    scale_factor = float(
-                        ROBOT_MIN_VOLUME / transfer.sample_volume)
-                    transfer.sample_volume *= scale_factor
-                    transfer.buffer_volume *= scale_factor
-                    transfer.scaled_up = True
-            except (TypeError, ZeroDivisionError) as e:
-                transfer.sample_volume = None
-                transfer.buffer_volume = None
-                transfer.has_to_evaporate = None
+        self.volume_calc_strategy.calculate_transfer_volumes(
+            transfers=self.transfers, scale_up_low_volumes=self.scale_up_low_volumes)
 
     def split_up_high_volume_rows(self):
         """
@@ -395,3 +382,27 @@ class DilutionScheme(object):
 
     def __str__(self):
         return "<DilutionScheme positioner={}>".format(self.robot_deck_positioner)
+
+    @staticmethod
+    def create(artifact_service, robot_name, scale_up_low_volumes=True,
+               concentration_ref=None, include_blanks=False, error_log_artifact=None,
+               volume_calc_method=None, make_pools=False):
+        volume_calc_strategy = None
+
+        if volume_calc_method == VOLUME_CALC_FIXED:
+            volume_calc_strategy = FixedVolumeCalc()
+        elif volume_calc_method == VOLUME_CALC_BY_CONC and make_pools is False:
+            volume_calc_strategy = OneToOneConcentrationCalc()
+        elif volume_calc_method == VOLUME_CALC_BY_CONC and make_pools is True:
+            pass
+        else:
+            raise ValueError(
+                "Choice for volume calculation method is not implemented. \n"
+                "volume calc method:  {}\n"
+                "make pools: {}".format(volume_calc_method, make_pools))
+
+        return DilutionScheme(
+            artifact_service=artifact_service, robot_name=robot_name,
+            scale_up_low_volumes=scale_up_low_volumes,
+            concentration_ref=concentration_ref, include_blanks=include_blanks,
+            error_log_artifact=error_log_artifact, volume_calc_strategy=volume_calc_strategy)

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -18,7 +18,7 @@ class TransferEndpoint(object):
     # TODO: Handle tube racks
 
     def __init__(self, aliquot, concentration_ref=None):
-        self.sample_name = aliquot.name
+        self.aliquot_name = aliquot.name
         self.well = aliquot.well
         self.container = aliquot.container
         self.concentration = self._referenced_concentration(
@@ -64,7 +64,7 @@ class SingleTransfer(object):
 
     def __init__(self, source_endpoint, destination_endpoint=None, pair_id=None):
         self.pair_id = pair_id
-        self.sample_name = source_endpoint.sample_name
+        self.aliquot_name = source_endpoint.aliquot_name
         self.is_control = source_endpoint.is_control
         self.is_source_from_original = source_endpoint.is_from_original
 
@@ -78,6 +78,7 @@ class SingleTransfer(object):
         self.source_well_index = None
         self.source_plate_pos = None
 
+        self.target_aliquot_name = None
         self.target_well = None
         self.target_container = None
         self.requested_concentration = None
@@ -98,6 +99,7 @@ class SingleTransfer(object):
         self.target_container = destination_endpoint.container
         self.requested_concentration = destination_endpoint.requested_concentration
         self.requested_volume = destination_endpoint.requested_volume
+        self.target_aliquot_name = destination_endpoint.aliquot_name
 
     def __str__(self):
         source = "source({}/{}, conc={})".format(self.source_container,
@@ -107,7 +109,7 @@ class SingleTransfer(object):
         return "{} => {}".format(source, target)
 
     def __repr__(self):
-        return "<SingleTransfer {}>".format(self.sample_name)
+        return "<SingleTransfer {}>".format(self.aliquot_name)
 
 
 class EndpointPositioner(object):
@@ -394,7 +396,7 @@ class DilutionScheme(object):
         elif volume_calc_method == VOLUME_CALC_BY_CONC and make_pools is False:
             volume_calc_strategy = OneToOneConcentrationCalc()
         elif volume_calc_method == VOLUME_CALC_BY_CONC and make_pools is True:
-            pass
+            volume_calc_strategy = PoolConcentrationCalc()
         else:
             raise ValueError(
                 "Choice for volume calculation method is not implemented. \n"

--- a/clarity_ext/dilution_strategies.py
+++ b/clarity_ext/dilution_strategies.py
@@ -1,3 +1,25 @@
+# These values, residing in SingleTransfer objects, are calculated in
+# the these strategy classes (except FixedVolumeCalc)
+#
+# Variables to be used in driver file and udf update calculations:
+#   sample_volume,
+#   the volume in ul taken from the source sample into the destination
+#
+#   buffer_volume,
+#   the volume in ul taken from water/buffer/EB
+#
+# Variables to serve as basis of producing warning messages at validation.
+#   has_to_evaporate,
+#   Is true when the specified required concentration exceeds the source
+#   concentration
+#
+#   scaled_up,
+#   When a sample volume is less than the pipetting min volume of 2 ul,
+#   both sample volume and buffer volume will be scaled up, still rendering
+#   the right concentration but higher volume than desired.
+
+from itertools import groupby
+
 ROBOT_MIN_VOLUME = 2
 
 
@@ -47,3 +69,69 @@ class OneToOneConcentrationCalc:
                 transfer.sample_volume = None
                 transfer.buffer_volume = None
                 transfer.has_to_evaporate = None
+
+
+class PoolConcentrationCalc:
+    """
+    Comments on key variable calculations:
+    * sample_volume,
+      depends on the number of samples contained within the pool, otherwise
+      like a one-to-one dilution
+    * buffer_volume,
+      based on requested volume and all sample volumes within the pool.
+      The buffer volume is specified at one single row in the driver
+      file, chosen at random among samples within the pool.
+    * has_to_evaporate,
+      same as previous, based on requested volume and all sample
+      volumes within the pool
+    * scaled_up,
+      the scale up factor is based on the min sample volume within the pool.
+      If volumes are to be scaled up, all sample volumes and the buffer volume
+      have to be scaled up.
+    """
+
+    def __init__(self):
+        pass
+
+    def calculate_transfer_volumes(self, transfers=None, scale_up_low_volumes=None):
+        transfers = sorted(transfers, key=lambda t: t.target_aliquot_name)
+        grouped_transfers = groupby(
+            transfers, key=lambda t: t.target_aliquot_name)
+        for key, group in grouped_transfers:
+            self._calc_single_pool(list(group), scale_up_low_volumes)
+
+    def _calc_single_pool(self, transfers, scale_up_low_volumes):
+        """
+        Calculate transfer volumes for a single pool
+        :param transfers: A list of transfers associated with a single pool
+        :return:
+        """
+        for transfer in transfers:
+            try:
+                transfer.sample_volume = \
+                    transfer.requested_concentration * transfer.requested_volume / \
+                    transfer.source_concentration / len(transfers)
+                transfer.buffer_volume = 0
+            except (TypeError, ZeroDivisionError):
+                transfer.sample_volume = 0
+                transfer.buffer_volume = 0
+                transfer.has_to_evaporate = False
+
+        t = transfers[0]
+        t.buffer_volume = max(t.requested_volume -
+                              sum([tt.sample_volume for tt in transfers]), 0)
+
+        min_sample_volume = min(map(lambda t: t.sample_volume, transfers))
+        for t in transfers:
+            t.has_to_evaporate = t.requested_volume - \
+                sum([tt.sample_volume for tt in transfers]) < 0
+            try:
+                if scale_up_low_volumes is True and min_sample_volume < ROBOT_MIN_VOLUME:
+                    scale_factor = float(ROBOT_MIN_VOLUME/min_sample_volume)
+                    t.sample_volume *= scale_factor
+                    t.buffer_volume *= scale_factor
+                    t.scaled_up = True
+            except ZeroDivisionError:
+                # Zero sample volume indicates an error that should be caught
+                # later by validation
+                pass

--- a/clarity_ext/dilution_strategies.py
+++ b/clarity_ext/dilution_strategies.py
@@ -1,0 +1,49 @@
+ROBOT_MIN_VOLUME = 2
+
+
+class FixedVolumeCalc:
+    """
+    Implements sample volume calculations for transfer only dilutions.
+    I.e. no calculations at all. The fixed transfer volume is specified in
+    individual scripts
+    """
+
+    def calculate_transfer_volumes(self, transfers=None, scale_up_low_volumes=None):
+        """
+        Do nothing
+        """
+        pass
+
+
+class OneToOneConcentrationCalc:
+    """
+    Implements sample volume calculations for a one to one dilution,
+    referring that a single transfer has a single source well/tube
+    and a single destination well/tube, i.e. no pooling involved.
+    Transfer volumes are calculated on basis of a requested target
+    concentration and target volume by the user.
+    """
+
+    def __init__(self):
+        pass
+
+    def calculate_transfer_volumes(self, transfers=None, scale_up_low_volumes=None):
+        for transfer in transfers:
+            try:
+                transfer.sample_volume = \
+                    transfer.requested_concentration * transfer.requested_volume / \
+                    transfer.source_concentration
+                transfer.buffer_volume = \
+                    max(transfer.requested_volume - transfer.sample_volume, 0)
+                transfer.has_to_evaporate = \
+                    (transfer.requested_volume - transfer.sample_volume) < 0
+                if scale_up_low_volumes and transfer.sample_volume < ROBOT_MIN_VOLUME:
+                    scale_factor = float(
+                        ROBOT_MIN_VOLUME / transfer.sample_volume)
+                    transfer.sample_volume *= scale_factor
+                    transfer.buffer_volume *= scale_factor
+                    transfer.scaled_up = True
+            except (TypeError, ZeroDivisionError) as e:
+                transfer.sample_volume = None
+                transfer.buffer_volume = None
+                transfer.has_to_evaporate = None

--- a/clarity_ext/domain/common.py
+++ b/clarity_ext/domain/common.py
@@ -33,6 +33,9 @@ class DomainObjectMixin(object):
                 continue
             elif any(b[key] is i for i in cache):
                 continue
+            elif a[key].__class__.__name__ == "MagicMock" and a[key].__class__.__name__ == "MagicMock":
+                # filter out mocked fields
+                continue
             elif not self._eq_rec(a[key], b[key], cache):
                 return False
         return True

--- a/clarity_ext/driverfile.py
+++ b/clarity_ext/driverfile.py
@@ -168,7 +168,8 @@ class ResponseFileService:
             yield "\t".join(row)
 
     def file_key(self, file_name):
-        match = re.match(r"(^24-\d+).*$", file_name)
+        # TODO: Files not matching with a ResultFile shouldn't be uploaded at all
+        match = re.match(r"(^(24|122)-\d+).*$", file_name)
         if match:
             return match.group(1)
         else:

--- a/clarity_ext/extensions.py
+++ b/clarity_ext/extensions.py
@@ -151,9 +151,6 @@ class ExtensionService(object):
                     module, self.RUN_MODE_FREEZE))
 
             for run_arguments in run_arguments_list:
-                step_prefix = "24-"
-                if not run_arguments["pid"].startswith(step_prefix):
-                    run_arguments["pid"] = "{}{}".format(step_prefix, run_arguments["pid"])
                 path = self._run_path(run_arguments, module, mode, config)
                 frozen_path = self._run_path(run_arguments, module, self.RUN_MODE_FREEZE, config)
 

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -101,16 +101,15 @@ class StepRepository(object):
             raise NotImplementedError(
                 "Generation type {} is not implemented".format(output_gen_type))
 
-        output_type = output_info["output-type"]
-        if output_type == "ResultFile":
+        if isinstance(output, ResultFile):
             output.output_type = Artifact.OUTPUT_TYPE_RESULT_FILE
-        elif output_type == "Analyte":
+        elif isinstance(output, Analyte):
             output.output_type = Artifact.OUTPUT_TYPE_ANALYTE
-        elif output_type == "SharedResultFile":
+        elif isinstance(output, SharedResultFile):
             output.output_type = Artifact.OUTPUT_TYPE_SHARED_RESULT_FILE
         else:
             raise NotImplementedError(
-                "Output type {} is not implemented".format(output_type))
+                "Output type {} is not implemented".format(output.__class__.__name__))
 
         # Add a reference to the other object for convenience:
         input.output = output

--- a/clarity_ext/service/artifact_service.py
+++ b/clarity_ext/service/artifact_service.py
@@ -33,7 +33,7 @@ class ArtifactService:
         """
         outputs = (outp for inp, outp in self.all_artifacts())
         shared_files = (
-            outp for outp in outputs if outp.generation_type == Artifact.PER_ALL_INPUTS)
+            outp for outp in outputs if isinstance(outp, SharedResultFile))
         ret = list(utils.unique(shared_files, lambda f: f.id))
         assert len(ret) == 0 or isinstance(ret[0], SharedResultFile)
         return ret

--- a/test/unit/clarity_ext/dilution/test_dilutions.py
+++ b/test/unit/clarity_ext/dilution/test_dilutions.py
@@ -40,7 +40,7 @@ class TestDilutionScheme(unittest.TestCase):
 
         # Test:
         actual = [
-            [dilute.sample_name,
+            [dilute.aliquot_name,
              dilute.source_well_index,
              dilute.source_plate_pos,
              round(dilute.sample_volume, 1),
@@ -69,7 +69,7 @@ class TestDilutionScheme(unittest.TestCase):
 
         # Test:
         actual = [
-            [dilute.sample_name,
+            [dilute.aliquot_name,
              dilute.source_well_index,
              dilute.source_plate_pos,
              round(dilute.sample_volume, 1),
@@ -122,7 +122,7 @@ class TestDilutionScheme(unittest.TestCase):
 
         # Test:
         actual = [
-            [dilute.sample_name,
+            [dilute.aliquot_name,
              dilute.source_well_index,
              dilute.source_plate_pos,
              round(dilute.sample_volume, 1),
@@ -173,7 +173,7 @@ class TestDilutionScheme(unittest.TestCase):
         ]
 
         actual = [
-            [dilute.sample_name,
+            [dilute.aliquot_name,
              dilute.source_well_index,
              dilute.source_plate_pos,
              round(dilute.sample_volume, 1),
@@ -241,7 +241,7 @@ class TestDilutionScheme(unittest.TestCase):
         ]
 
         actual = [
-            [dilute.sample_name,
+            [dilute.aliquot_name,
              dilute.source_well_index,
              dilute.source_plate_pos,
              round(dilute.sample_volume, 1),
@@ -293,7 +293,7 @@ class TestDilutionScheme(unittest.TestCase):
 
         # Test:
         actual = [
-            [dilute.sample_name,
+            [dilute.aliquot_name,
              dilute.source_well_index,
              dilute.source_plate_pos,
              4,
@@ -420,9 +420,9 @@ def pre_validate_dilution(dilution_scheme):
     """
     for transfer in dilution_scheme.transfers:
         if not transfer.source_initial_volume:
-            yield ValidationException("{}, source volume is not set.".format(transfer.sample_name))
+            yield ValidationException("{}, source volume is not set.".format(transfer.aliquot_name))
         if not transfer.source_concentration:
-            yield ValidationException("{}, source concentration not set.".format(transfer.sample_name))
+            yield ValidationException("{}, source concentration not set.".format(transfer.aliquot_name))
 
 
 def post_validate_dilution(dilution_scheme):
@@ -435,16 +435,16 @@ def post_validate_dilution(dilution_scheme):
     for transfer_group in dilution_scheme.grouped_transfers:
         total_volume = sum(map(lambda t: t.sample_volume +
                                t.buffer_volume, transfer_group))
-        sample_name = transfer_group[0].sample_name
+        aliquot_name = transfer_group[0].aliquot_name
         pos_spec = pos_str(transfer_group[0])
         has_to_evaporate = transfer_group[0].has_to_evaporate
 
         if total_volume > 100:
             yield ValidationException("{}, too high destination volume ({}).".format(
-                sample_name, pos_spec))
+                aliquot_name, pos_spec))
         if has_to_evaporate:
             yield ValidationException("{}, sample has to be evaporated ({}).".format(
-                sample_name, pos_spec), ValidationType.WARNING)
+                aliquot_name, pos_spec), ValidationType.WARNING)
 
 
 if __name__ == "__main__":

--- a/test/unit/clarity_ext/dilution/test_dilutions.py
+++ b/test/unit/clarity_ext/dilution/test_dilutions.py
@@ -3,6 +3,8 @@ from mock import MagicMock
 from clarity_ext.dilution import DilutionScheme
 from clarity_ext.dilution import CONCENTRATION_REF_NGUL
 from clarity_ext.dilution import CONCENTRATION_REF_NM
+from clarity_ext.dilution import VOLUME_CALC_BY_CONC
+from clarity_ext.dilution import VOLUME_CALC_FIXED
 from test.unit.clarity_ext.helpers import fake_analyte, fake_result_file
 from test.unit.clarity_ext import helpers
 from clarity_ext.service import ArtifactService
@@ -17,10 +19,12 @@ class TestDilutionScheme(unittest.TestCase):
     """
 
     def _default_dilution_scheme(self, artifact_service, concentration_ref=CONCENTRATION_REF_NGUL,
-                                 include_blanks=False):
-        return DilutionScheme(artifact_service=artifact_service, robot_name="Hamilton",
-                              scale_up_low_volumes=True, concentration_ref=concentration_ref,
-                              include_blanks=include_blanks)
+                                 include_blanks=False, volume_calc_method=VOLUME_CALC_BY_CONC,
+                                 scale_up_low_volumes=True):
+        return DilutionScheme.create(artifact_service=artifact_service, robot_name="Hamilton",
+                                     scale_up_low_volumes=scale_up_low_volumes,
+                                     concentration_ref=concentration_ref,
+                                     include_blanks=include_blanks, volume_calc_method=volume_calc_method)
 
     def test_dilution_scheme_hamilton_base(self):
         """Dilution scheme created by mocked analytes is correctly generated for Hamilton"""
@@ -278,7 +282,8 @@ class TestDilutionScheme(unittest.TestCase):
 
         svc = helpers.mock_artifact_service(analyte_result_file_set)
 
-        dilution_scheme = self._default_dilution_scheme(svc, include_blanks=True)
+        dilution_scheme = self._default_dilution_scheme(
+            svc, include_blanks=True, volume_calc_method=VOLUME_CALC_FIXED)
 
         expected = [
             ['art-name1', 36, 'DNA1', 4, 0, 36, 'END1'],
@@ -310,8 +315,6 @@ class TestDilutionScheme(unittest.TestCase):
                               requested_concentration_ngul=1000, requested_volume=2))
             ]
 
-            return inputs, outputs
-
         repo = MagicMock()
         repo.all_artifacts = invalid_analyte_set
         svc = ArtifactService(repo)
@@ -331,12 +334,9 @@ class TestDilutionScheme(unittest.TestCase):
                               requested_concentration_ngul=10, requested_volume=200))
             ]
 
-            return inputs, outputs
-
-        repo = MagicMock()
-        repo.all_artifacts = invalid_analyte_set
-        svc = ArtifactService(repo)
-        dilution_scheme = self._default_dilution_scheme(svc)
+        svc = helpers.mock_artifact_service(invalid_analyte_set)
+        dilution_scheme = self._default_dilution_scheme(
+            artifact_service=svc, scale_up_low_volumes=False)
         actual = set(str(result)
                      for result in post_validate_dilution(dilution_scheme))
         expected = set(

--- a/test/unit/clarity_ext/dilution/test_pooling.py
+++ b/test/unit/clarity_ext/dilution/test_pooling.py
@@ -1,0 +1,443 @@
+import unittest
+from mock import MagicMock
+from clarity_ext.dilution import DilutionScheme
+from clarity_ext.dilution import CONCENTRATION_REF_NM
+from clarity_ext.dilution import VOLUME_CALC_BY_CONC
+from clarity_ext.domain.validation import ValidationException
+from clarity_ext.domain.validation import ValidationType
+from test.unit.clarity_ext.helpers import fake_analyte
+from test.unit.clarity_ext.helpers import print_list
+from test.unit.clarity_ext import helpers
+
+
+UDF_MAP = {
+            "requested_concentration_nm": "Target Concentration",
+            "requested_volume": "Target Volume",
+            "concentration_nm": "Conc",
+            "volume": "Vol"
+          }
+
+
+class TestLibraryPooling(unittest.TestCase):
+    def _default_dilution_scheme(self, artifact_service, scale_up_low_volumes=True):
+        return DilutionScheme.create(artifact_service=artifact_service, robot_name="Hamilton",
+                                     scale_up_low_volumes=scale_up_low_volumes,
+                                     concentration_ref=CONCENTRATION_REF_NM, include_blanks=False,
+                                     volume_calc_method=VOLUME_CALC_BY_CONC, make_pools=True)
+
+    def test_single_pool_creation(self):
+        def pooled_analyte_set():
+            samples = ["sample1", "sample2", "sample3"]
+            pool = fake_analyte("cont2", "art4", samples, "Pool1", "B:4",
+                                is_input=False, udf_map=UDF_MAP,
+                                requested_concentration_nm=15, requested_volume=40)
+            return [
+                (fake_analyte("cont1", "art1", "sample1", "analyte1", "A:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=10, volume=300),
+                 pool),
+                (fake_analyte("cont1", "art2", "sample2", "analyte2", "A:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=25, volume=300),
+                 pool),
+                (fake_analyte("cont1", "art3", "sample3", "analyte3", "A:3", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=30, volume=300),
+                 pool),
+            ]
+
+        svc = helpers.mock_artifact_service(pooled_analyte_set)
+        dilution_scheme = self._default_dilution_scheme(svc)
+
+        expected = [
+            ['analyte1', 1, 'DNA1', 20.0, 5.3, 26, 'END1'],
+            ['analyte2', 9, 'DNA1', 8.0, 0, 26, 'END1'],
+            ['analyte3', 17, 'DNA1', 6.7, 0, 26, 'END1'],
+        ]
+
+        # Test:
+        actual = [
+            [dilute.aliquot_name,
+             dilute.source_well_index,
+             dilute.source_plate_pos,
+             round(dilute.sample_volume, 1),
+             round(dilute.buffer_volume, 1),
+             dilute.target_well_index,
+             dilute.target_plate_pos] for dilute in dilution_scheme.transfers
+        ]
+
+        validation_results = list(post_validate_dilution(dilution_scheme))
+
+        # Assert:
+        self.assertEqual(expected, actual)
+        self.assertEqual(0, len(validation_results))
+
+    def test_two_pools_creation(self):
+        svc = helpers.mock_artifact_service(two_pool_analyte_set)
+        dilution_scheme = self._default_dilution_scheme(svc)
+
+        expected = [
+            ['analyte1', 1, 'DNA1', 20.0, 5.3, 26, 'END1'],
+            ['analyte2', 2, 'DNA1', 8.0, 0, 26, 'END1'],
+            ['analyte3', 3, 'DNA1', 6.7, 0, 26, 'END1'],
+            ['analyte4', 9, 'DNA1', 20.0, 5.3, 27, 'END1'],
+            ['analyte5', 10, 'DNA1', 8.0, 0, 27, 'END1'],
+            ['analyte6', 11, 'DNA1', 6.7, 0, 27, 'END1'],
+        ]
+
+        # Test:
+        actual = [
+            [dilute.aliquot_name,
+             dilute.source_well_index,
+             dilute.source_plate_pos,
+             round(dilute.sample_volume, 1),
+             round(dilute.buffer_volume, 1),
+             dilute.target_well_index,
+             dilute.target_plate_pos] for dilute in dilution_scheme.transfers
+        ]
+
+        validation_results = list(post_validate_dilution(dilution_scheme))
+
+        print_list(expected, "expected")
+        print_list(actual, "actual")
+
+        # Assert:
+        self.assertEqual(expected, actual)
+        self.assertEqual(0, len(validation_results))
+
+    def test_dilution_scheme_source_volume_not_set(self):
+        def invalid_analyte_set():
+            pool1 = fake_analyte("cont-id1", "art-id1", ["sample1", "sample2"], "pool1", "B:5",
+                                  False, requested_concentration_nm=100, requested_volume=20)
+            return [
+                    (fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5",
+                                  True, concentration_nm=100),
+                     pool1),
+                    (fake_analyte("cont-id1", "art-id1", "sample2", "art-name1", "D:5",
+                                  True, concentration_nm=100, volume=20),
+                     pool1),
+                    ]
+        svc = helpers.mock_artifact_service(invalid_analyte_set)
+        dilution_scheme = self._default_dilution_scheme(svc)
+        actual = set(str(result)
+                     for result in pre_validate_dilution(dilution_scheme))
+        expected = set(["Error: art-name1, source volume is not set."])
+        self.assertEqual(expected, actual)
+
+    def test_dilution_scheme_source_concentration_not_set(self):
+        def invalid_analyte_set():
+            pool1 = fake_analyte("cont-id1", "art-id1", ["sample1", "sample2"], "pool1", "B:5",
+                                  False, requested_concentration_nm=100, requested_volume=20)
+            return [
+                    (fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5",
+                                  True, volume=100),
+                     pool1),
+                    (fake_analyte("cont-id1", "art-id1", "sample2", "art-name1", "D:5",
+                                  True, concentration_nm=100, volume=20),
+                     pool1),
+                    ]
+        svc = helpers.mock_artifact_service(invalid_analyte_set)
+        dilution_scheme = self._default_dilution_scheme(svc)
+        actual = set(str(result)
+                     for result in pre_validate_dilution(dilution_scheme))
+        expected = set(["Error: art-name1, source concentration not set."])
+        self.assertEqual(expected, actual)
+
+    def test_dilution_scheme_source_concentration_zero(self):
+        def invalid_analyte_set():
+            pool1 = fake_analyte("cont-id1", "art-id1", ["sample1", "sample2"], "pool1", "B:5",
+                                  False, requested_concentration_nm=100, requested_volume=20)
+            return [
+                    (fake_analyte("cont-id1", "art-id1", "sample1", "art-name1", "D:5",
+                                  True, concentration_nm=0, volume=100),
+                     pool1),
+                    (fake_analyte("cont-id1", "art-id1", "sample2", "art-name1", "D:5",
+                                  True, concentration_nm=100, volume=20),
+                     pool1),
+                    ]
+        svc = helpers.mock_artifact_service(invalid_analyte_set)
+        dilution_scheme = self._default_dilution_scheme(svc)
+        actual = set(str(result)
+                     for result in pre_validate_dilution(dilution_scheme))
+        expected = set(["Error: art-name1, source concentration not set."])
+        self.assertEqual(expected, actual)
+
+    def test_too_high_destination_volume(self):
+        def invalid_analyte_set():
+            samples = ["sample1", "sample2", "sample3"]
+            pool1 = fake_analyte("cont2", "art4", samples, "Pool1", "B:4",
+                                is_input=False, udf_map=UDF_MAP,
+                                requested_concentration_nm=15, requested_volume=40)
+            samples = ["sample4", "sample5", "sample6"]
+            pool2 = fake_analyte("cont2", "art5", samples, "Pool2", "C:4",
+                                is_input=False, udf_map=UDF_MAP,
+                                requested_concentration_nm=15, requested_volume=101)
+            return [
+                (fake_analyte("cont1", "art1", "sample1", "analyte1", "A:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=10, volume=300),
+                 pool1),
+                (fake_analyte("cont1", "art2", "sample2", "analyte2", "B:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=25, volume=300),
+                 pool1),
+                (fake_analyte("cont1", "art3", "sample3", "analyte3", "C:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=30, volume=300),
+                 pool1),
+                (fake_analyte("cont1", "art4", "sample4", "analyte4", "A:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=10, volume=300),
+                 pool2),
+                (fake_analyte("cont1", "art5", "sample5", "analyte5", "B:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=25, volume=300),
+                 pool2),
+                (fake_analyte("cont1", "art6", "sample6", "analyte6", "C:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=30, volume=300),
+                 pool2),
+            ]
+
+        svc = helpers.mock_artifact_service(invalid_analyte_set)
+        dilution_scheme = self._default_dilution_scheme(svc)
+        actual = set(str(result)
+                     for result in post_validate_dilution(dilution_scheme))
+        expected = set(["Error: Pool2, too high destination volume (cont2(C4))."])
+        self.assertEqual(expected, actual)
+
+    def test_too_high_destination_volume_due_to_evaporation(self):
+        def invalid_analyte_set():
+            samples = ["sample1", "sample2", "sample3"]
+            pool1 = fake_analyte("cont2", "art4", samples, "Pool1", "B:4",
+                                is_input=False, udf_map=UDF_MAP,
+                                requested_concentration_nm=15, requested_volume=40)
+            samples = ["sample4", "sample5", "sample6"]
+            pool2 = fake_analyte("cont2", "art5", samples, "Pool2", "C:4",
+                                is_input=False, udf_map=UDF_MAP,
+                                requested_concentration_nm=40, requested_volume=70)
+            return [
+                (fake_analyte("cont1", "art1", "sample1", "analyte1", "A:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=10, volume=300),
+                 pool1),
+                (fake_analyte("cont1", "art2", "sample2", "analyte2", "B:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=25, volume=300),
+                 pool1),
+                (fake_analyte("cont1", "art3", "sample3", "analyte3", "C:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=30, volume=300),
+                 pool1),
+                (fake_analyte("cont1", "art4", "sample4", "analyte4", "A:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=10, volume=300),
+                 pool2),
+                (fake_analyte("cont1", "art5", "sample5", "analyte5", "B:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=25, volume=300),
+                 pool2),
+                (fake_analyte("cont1", "art6", "sample6", "analyte6", "C:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=30, volume=300),
+                 pool2),
+            ]
+
+        svc = helpers.mock_artifact_service(invalid_analyte_set)
+        dilution_scheme = self._default_dilution_scheme(svc)
+        actual = set(str(result)
+                     for result in post_validate_dilution(dilution_scheme))
+        expected = set(["Error: Pool2, too high destination volume (cont2(C4)).",
+                       "Warning: Pool2, pool has to be evaporated (cont2(C4))."])
+        self.assertEqual(expected, actual)
+
+    def test_evaporation_warning(self):
+        def invalid_analyte_set():
+            samples = ["sample1", "sample2", "sample3"]
+            pool1 = fake_analyte("cont2", "art4", samples, "Pool1", "B:4",
+                                is_input=False, udf_map=UDF_MAP,
+                                requested_concentration_nm=15, requested_volume=40)
+            samples = ["sample4", "sample5", "sample6"]
+            pool2 = fake_analyte("cont2", "art5", samples, "Pool2", "C:4",
+                                is_input=False, udf_map=UDF_MAP,
+                                requested_concentration_nm=30, requested_volume=30)
+            return [
+                (fake_analyte("cont1", "art1", "sample1", "analyte1", "A:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=10, volume=300),
+                 pool1),
+                (fake_analyte("cont1", "art2", "sample2", "analyte2", "B:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=25, volume=300),
+                 pool1),
+                (fake_analyte("cont1", "art3", "sample3", "analyte3", "C:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=30, volume=300),
+                 pool1),
+                (fake_analyte("cont1", "art4", "sample4", "analyte4", "A:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=10, volume=300),
+                 pool2),
+                (fake_analyte("cont1", "art5", "sample5", "analyte5", "B:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=25, volume=300),
+                 pool2),
+                (fake_analyte("cont1", "art6", "sample6", "analyte6", "C:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=30, volume=300),
+                 pool2),
+            ]
+
+        svc = helpers.mock_artifact_service(invalid_analyte_set)
+        dilution_scheme = self._default_dilution_scheme(svc)
+        actual = set(str(result)
+                     for result in post_validate_dilution(dilution_scheme))
+        expected = set(
+            ["Warning: Pool2, pool has to be evaporated (cont2(C4))."])
+        self.assertEqual(expected, actual)
+
+    def test_scaled_up_warning(self):
+        def invalid_analyte_set():
+            samples = ["sample1", "sample2", "sample3"]
+            pool1 = fake_analyte("cont2", "art4", samples, "Pool1", "B:4",
+                                is_input=False, udf_map=UDF_MAP,
+                                requested_concentration_nm=15, requested_volume=5)
+            samples = ["sample4", "sample5", "sample6"]
+            pool2 = fake_analyte("cont2", "art5", samples, "Pool2", "C:4",
+                                is_input=False, udf_map=UDF_MAP,
+                                requested_concentration_nm=10, requested_volume=40)
+            return [
+                (fake_analyte("cont1", "art1", "sample1", "analyte1", "A:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=10, volume=300),
+                 pool1),
+                (fake_analyte("cont1", "art2", "sample2", "analyte2", "B:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=25, volume=300),
+                 pool1),
+                (fake_analyte("cont1", "art3", "sample3", "analyte3", "C:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=30, volume=300),
+                 pool1),
+                (fake_analyte("cont1", "art4", "sample4", "analyte4", "A:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=10, volume=300),
+                 pool2),
+                (fake_analyte("cont1", "art5", "sample5", "analyte5", "B:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=25, volume=300),
+                 pool2),
+                (fake_analyte("cont1", "art6", "sample6", "analyte6", "C:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=30, volume=300),
+                 pool2),
+            ]
+
+        svc = helpers.mock_artifact_service(invalid_analyte_set)
+        dilution_scheme = self._default_dilution_scheme(svc)
+        actual = set(str(result)
+                     for result in post_validate_dilution(dilution_scheme))
+        expected = set(
+            ["Warning: Pool1, volume has been scaled up due to the min pipetting volume of 2 ul (cont2(B4))."])
+        self.assertEqual(expected, actual)
+
+    def test_scaled_up_and_splitted_rows(self):
+        def invalid_analyte_set():
+            samples = ["sample1", "sample2", "sample3"]
+            pool1 = fake_analyte("cont2", "art4", samples, "Pool1", "B:4",
+                                is_input=False, udf_map=UDF_MAP,
+                                requested_concentration_nm=15, requested_volume=40)
+            samples = ["sample4", "sample5", "sample6"]
+            pool2 = fake_analyte("cont2", "art5", samples, "Pool2", "C:4",
+                                is_input=False, udf_map=UDF_MAP,
+                                requested_concentration_nm=7, requested_volume=80)
+            return [
+                (fake_analyte("cont1", "art1", "sample1", "analyte1", "A:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=10, volume=300),
+                 pool1),
+                (fake_analyte("cont1", "art2", "sample2", "analyte2", "B:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=25, volume=300),
+                 pool1),
+                (fake_analyte("cont1", "art3", "sample3", "analyte3", "C:1", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=30, volume=300),
+                 pool1),
+                (fake_analyte("cont1", "art4", "sample4", "analyte4", "A:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=3, volume=300),
+                 pool2),
+                (fake_analyte("cont1", "art5", "sample5", "analyte5", "B:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=25, volume=300),
+                 pool2),
+                (fake_analyte("cont1", "art6", "sample6", "analyte6", "C:2", is_input=True, udf_map=UDF_MAP,
+                              concentration_nm=180, volume=300),
+                 pool2),
+            ]
+
+        svc = helpers.mock_artifact_service(invalid_analyte_set)
+        dilution_scheme = self._default_dilution_scheme(svc)
+
+        expected = [
+            ['analyte1', 1, 'DNA1', 20.0, 5.3, 26, 'END1'],
+            ['analyte2', 2, 'DNA1', 8.0, 0, 26, 'END1'],
+            ['analyte3', 3, 'DNA1', 6.7, 0, 26, 'END1'],
+            ['analyte4', 9, 'DNA1', 40.0, 17.9, 27, 'END1'],
+            ['analyte4', 9, 'DNA1', 40.0, 0, 27, 'END1'],
+            ['analyte4', 9, 'DNA1', 40.0, 0, 27, 'END1'],
+            ['analyte5', 10, 'DNA1', 14.4, 0, 27, 'END1'],
+            ['analyte6', 11, 'DNA1', 2, 0, 27, 'END1'],
+        ]
+
+        # Test:
+        actual = [
+            [dilute.aliquot_name,
+             dilute.source_well_index,
+             dilute.source_plate_pos,
+             round(dilute.sample_volume, 1),
+             round(dilute.buffer_volume, 1),
+             dilute.target_well_index,
+             dilute.target_plate_pos] for dilute in dilution_scheme.transfers
+        ]
+
+        print_list(expected, "expected")
+        print_list(actual, "actual")
+
+        # Assert:
+        self.assertEqual(expected, actual)
+
+
+def two_pool_analyte_set():
+    samples = ["sample1", "sample2", "sample3"]
+    pool1 = fake_analyte("cont2", "art4", samples, "Pool1", "B:4",
+                        is_input=False, udf_map=UDF_MAP,
+                        requested_concentration_nm=15, requested_volume=40)
+    samples = ["sample4", "sample5", "sample6"]
+    pool2 = fake_analyte("cont2", "art5", samples, "Pool2", "C:4",
+                        is_input=False, udf_map=UDF_MAP,
+                        requested_concentration_nm=15, requested_volume=40)
+    return [
+        (fake_analyte("cont1", "art1", "sample1", "analyte1", "A:1", is_input=True, udf_map=UDF_MAP,
+                      concentration_nm=10, volume=300),
+         pool1),
+        (fake_analyte("cont1", "art4", "sample4", "analyte4", "A:2", is_input=True, udf_map=UDF_MAP,
+                      concentration_nm=10, volume=300),
+         pool2),
+        (fake_analyte("cont1", "art2", "sample2", "analyte2", "B:1", is_input=True, udf_map=UDF_MAP,
+                      concentration_nm=25, volume=300),
+         pool1),
+        (fake_analyte("cont1", "art3", "sample3", "analyte3", "C:1", is_input=True, udf_map=UDF_MAP,
+                      concentration_nm=30, volume=300),
+         pool1),
+        (fake_analyte("cont1", "art5", "sample5", "analyte5", "B:2", is_input=True, udf_map=UDF_MAP,
+                      concentration_nm=25, volume=300),
+         pool2),
+        (fake_analyte("cont1", "art6", "sample6", "analyte6", "C:2", is_input=True, udf_map=UDF_MAP,
+                      concentration_nm=30, volume=300),
+         pool2),
+    ]
+
+
+def pre_validate_dilution(dilution_scheme):
+    """
+    Check that all pertinent variables are initiated so that calculations
+    are possible to perform
+    """
+    for transfer in dilution_scheme.transfers:
+        if not transfer.source_initial_volume:
+            yield ValidationException("{}, source volume is not set.".format(transfer.aliquot_name))
+        if not transfer.source_concentration:
+            yield ValidationException("{}, source concentration not set.".format(transfer.aliquot_name))
+
+
+def post_validate_dilution(dilution_scheme):
+    """
+    Check calculation results if its conform to hardware restrictions
+    """
+    def pos_str(transfer):
+        return "{}".format(transfer.target_well)
+
+    for g in dilution_scheme.grouped_transfers:
+        total_volume = sum(map(lambda t: t.sample_volume +
+                               t.buffer_volume, g))
+
+        if total_volume > 100:
+            yield ValidationException("{}, too high destination volume ({}).".format(
+                g[0].target_aliquot_name, pos_str(g[0])))
+        if g[0].has_to_evaporate:
+            yield ValidationException("{}, pool has to be evaporated ({}).".format(
+                g[0].target_aliquot_name, pos_str(g[0])), ValidationType.WARNING)
+        if g[0].scaled_up:
+            yield ValidationException("{}, volume has been scaled up due to "
+                                      "the min pipetting volume of 2 ul ({}).".format(
+                g[0].target_aliquot_name, pos_str(g[0])), ValidationType.WARNING)

--- a/test/unit/clarity_ext/dilution/test_update_fields.py
+++ b/test/unit/clarity_ext/dilution/test_update_fields.py
@@ -40,7 +40,7 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
         expected = 29.0
         outcome = self.dilution_scheme.aliquot_pair_by_transfer[
             dilute].input_artifact.volume
-        print(dilute.sample_name)
+        print(dilute.aliquot_name)
         self.assertEqual(expected, outcome)
 
     def test_source_volume_update_all(self):
@@ -58,9 +58,9 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
         aliquot_pair_by_transfer = self.dilution_scheme.aliquot_pair_by_transfer
         for transfer in self.dilution_scheme.transfers:
             source_aliquot = aliquot_pair_by_transfer[transfer].input_artifact
-            print("transfer sample name: {}".format(transfer.sample_name))
+            print("transfer sample name: {}".format(transfer.aliquot_name))
             print("source aliquot sample name: {}".format(source_aliquot.name))
-            self.assertEqual(transfer.sample_name, source_aliquot.name)
+            self.assertEqual(transfer.aliquot_name, source_aliquot.name)
 
 
 def analyte_set_with_blank():

--- a/test/unit/clarity_ext/dilution/test_update_fields.py
+++ b/test/unit/clarity_ext/dilution/test_update_fields.py
@@ -3,6 +3,7 @@ from clarity_ext.dilution import DILUTION_WASTE_VOLUME
 from mock import MagicMock
 from clarity_ext.dilution import DilutionScheme
 from clarity_ext.dilution import CONCENTRATION_REF_NGUL
+from clarity_ext.dilution import VOLUME_CALC_BY_CONC
 from test.unit.clarity_ext import helpers
 from test.unit.clarity_ext.helpers import fake_analyte
 
@@ -14,8 +15,9 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
 
     def _init_dilution_scheme(self, concentration_ref):
         svc = helpers.mock_artifact_service(analyte_set_with_blank)
-        self.dilution_scheme = DilutionScheme(
-            svc, "Hamilton", concentration_ref=concentration_ref)
+        self.dilution_scheme = DilutionScheme.create(
+            artifact_service=svc, robot_name="Hamilton",
+            concentration_ref=concentration_ref, volume_calc_method=VOLUME_CALC_BY_CONC)
 
         analyte_pair_by_dilute = self.dilution_scheme.aliquot_pair_by_transfer
         for dilute in self.dilution_scheme.transfers:

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -37,7 +37,7 @@ def fake_result_file(artifact_id=None, name=None, container_id=None, well_key=No
     return ret
 
 
-def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_name=None,
+def fake_analyte(container_id=None, artifact_id=None, sample_ids=None, analyte_name=None,
                  well_key=None, is_input=None, is_control=False, udf_map=None, api_resource=None,
                  **kwargs):
     """
@@ -54,12 +54,14 @@ def fake_analyte(container_id=None, artifact_id=None, sample_id=None, analyte_na
     container = fake_container(container_id)
     pos = ContainerPosition.create(well_key)
     well = Well(pos, container)
-    sample = Sample(sample_id, sample_id, MagicMock())
+    if not isinstance(sample_ids, list):
+        sample_ids = [sample_ids]
+    samples = [Sample(id, id, MagicMock()) for id in sample_ids]
     if not udf_map:
         udf_map = DEFAULT_UDF_MAP['Analyte']
     analyte = Analyte(api_resource=api_resource, is_input=is_input,
                       name=analyte_name, well=well, is_control=is_control,
-                      sample=sample, artifact_specific_udf_map=udf_map, **kwargs)
+                      samples=samples, artifact_specific_udf_map=udf_map, **kwargs)
     analyte.id = artifact_id
     analyte.generation_type = Artifact.PER_INPUT
     well.artifact = analyte
@@ -153,3 +155,21 @@ def two_containers_artifact_set():
                       requested_concentration_ngul=100, requested_volume=20))
     ]
     return ret
+
+
+def print_out_dict(object_list, caption):
+    print("{}:".format(caption))
+    print("-----------------------------------------")
+    for o in object_list:
+        print("{}:".format(o))
+        for key in o.__dict__:
+            print("{} {}".format(key, o.__dict__[key]))
+        print("-----------------------------------------\n")
+
+
+def print_list(object_list, caption):
+    print("{}:".format(caption))
+    print("-------------------------------------------")
+    for o in object_list:
+        print("{}".format(o))
+    print("-------------------------------------------\n")


### PR DESCRIPTION
Support driver file generation and updating udfs at pool creation steps. 

Implementation of function calculate_transfer_volumes is delegated out
to classes that is dedicated to the type of dilution:
* FixedVolumeCalc
* OneToOneConcentrationCalc
* PoolConcentrationCalc

The code in class PoolConcentrationCalc is new in this pull request. Here, source samples (representated by one end of a transfer
object) are first grouped so that there are a single destination pool within each group.

More information on how the calculation goes is written in the code comments.
