### PR TITLE
Support freezing logs

### DIFF
--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -35,7 +35,10 @@ class Analyte(Aliquot):
         self.is_output_from_previous = is_from_original
 
     def __repr__(self):
-        return "{} ({})".format(self.name, self.id)
+        typename = type(self).__name__
+        if self.is_input is not None:
+            typename = ("Input" if self.is_input else "Output") + typename
+        return "{}<{} ({})>".format(typename, self.name, self.id)
 
     @staticmethod
     def create_from_rest_resource(resource, is_input, udf_map, container_repo):

--- a/clarity_ext/domain/result_file.py
+++ b/clarity_ext/domain/result_file.py
@@ -53,4 +53,5 @@ class ResultFile(Aliquot):
         return utils.single(self.samples)
 
     def __repr__(self):
-        return self.id
+        typename = type(self).__name__
+        return "{}<{} ({})>".format(typename, self.name, self.id)

--- a/clarity_ext/domain/shared_result_file.py
+++ b/clarity_ext/domain/shared_result_file.py
@@ -28,3 +28,7 @@ class SharedResultFile(Artifact):
                 original_rest_resource, updated_fields)
 
         return _updated_rest_resource, self.assigner.consume()
+
+    def __repr__(self):
+        typename = type(self).__name__
+        return "{}<{} ({})>".format(typename, self.name, self.id)

--- a/clarity_ext/domain/udf.py
+++ b/clarity_ext/domain/udf.py
@@ -3,6 +3,9 @@ from clarity_ext.domain.common import DomainObjectMixin
 from clarity_ext.utils import lazyprop
 from clarity_ext.domain.common import AssignLogger
 from clarity_ext.unit_conversion import UnitConversion
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Udf(DomainObjectMixin):
@@ -30,6 +33,10 @@ class Udf(DomainObjectMixin):
         self.assigner = AssignLogger(self)
 
     def set_udf(self, name, value, from_unit=None, to_unit=None):
+        # Log which UDFs have been set. This is used by integration tests that test
+        # if the UDFs have been tested without actually updating the backend.
+        logger.info("{object}[{udf}] := {value}".format(udf=name, value=value,
+                                                      object=self))
         if from_unit:
             units = UnitConversion()
             value = units.convert(value, from_unit, to_unit)

--- a/clarity_ext/service/artifact_service.py
+++ b/clarity_ext/service/artifact_service.py
@@ -115,7 +115,15 @@ class ArtifactService:
         assert len(ret) == 0 or isinstance(ret[0], ResultFile)
         return ret
 
-    def update_artifacts(self, update_queue):
+    def update_artifacts(self, update_queue, whatif=False):
+        """
+        :param update_queue: The items to be updated
+        :param whatif: True if artifacts shouldn't be updated (log only)
+        """
+        if whatif:
+            self.logger.info("A request for updating artifacts was ignored. "
+                             "View log to see which properties have changed.")
+            return
         response = self.step_repository.update_artifacts(update_queue)
         return response
 

--- a/clarity_ext/service/file_service.py
+++ b/clarity_ext/service/file_service.py
@@ -79,7 +79,7 @@ class FileService:
                     self.logger.info("Downloading file {} (artifact={} '{}')"
                                      .format(file.id, artifact.id, artifact.name))
                     self.file_repo.copy_remote_file(file.id, local_path)
-                    self.logger.info("Download completed, path='{}'".format(local_path))
+                    self.logger.info("Download completed, path='{}'".format(os.path.relpath(local_path)))
 
                     if self.should_cache:
                         if not os.path.exists(cache_directory):
@@ -118,7 +118,7 @@ class FileService:
         for path in self._local_shared_files:
             if os.path.exists(path):
                 self.logger.info("Local shared file '{}' will be removed to ensure "
-                                 "that it won't be uploaded again".format(path))
+                                 "that it won't be uploaded again".format(os.path.relpath(path)))
                 # TODO: Handle exception
                 os.remove(path)
 

--- a/test/integration/integration_test_service.py
+++ b/test/integration/integration_test_service.py
@@ -25,10 +25,13 @@ class IntegrationTest:
     """
 
     def __init__(self, pid=None, run_argument_dict=None, update_matrix_by_limsid=None,
-                 update_matrix_by_artnames=None):
+                 update_matrix_by_artnames=None, commit=True):
+        """
+        :param commit: Set to False to override all calls to commit on the context object.
+        """
         self.run_argument_dict = {}
         if pid:
-            self.run_argument_dict = {"pid": pid}
+            self.run_argument_dict = {"pid": pid, "commit": commit}
         if run_argument_dict:
             self.run_argument_dict.update(run_argument_dict)
 
@@ -38,9 +41,16 @@ class IntegrationTest:
         self.preparer = None
         self.preparer = IntegrationTestPrepare(
             update_matrix_by_limsid=update_matrix_by_limsid, update_matrix_by_artnames=update_matrix_by_artnames)
+        self.commit = commit
 
     def pid(self):
         return self.run_argument_dict["pid"]
+
+    def __getitem__(self, item):
+        return self.run_argument_dict[item]
+
+    def __repr__(self):
+        return repr(self.run_argument_dict)
 
 
 class IntegrationTestPrepare:


### PR DESCRIPTION
- Log files should be frozen along with generated data
- Support test_mode exeuction of extensions. These ensure that
  generated data does remain constant between test runs.
- Support disabling commits while running extension integration tests
- Change the representation of a few domain objects, for log output
- Log UDF assignments so they can be compared between runs
- Add a handler for logging while testing. This handler only logs the
  log entries that were logged during execution of the extension
  and they land up in the run-test directory so they will eventually
  be frozen.
- Add a new execution method for extensions, test-fresh, which ignores
  the frozen cache
- Minor non-interface breaking related fixes