### PR TITLE
Lims 809 fix update fields

### DIFF
--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -101,6 +101,13 @@ class SingleTransfer(object):
         self.requested_volume = destination_endpoint.requested_volume
         self.target_aliquot_name = destination_endpoint.aliquot_name
 
+    def identifier(self):
+        source = "source({}, conc={})".format(
+            self.source_well, self.source_concentration)
+        target = "target({}, conc={}, vol={})".format(self.target_well,
+                                                      self.requested_concentration, self.requested_volume)
+        return "{} => {}".format(source, target)
+
     def __str__(self):
         source = "source({}, conc={})".format(
             self.source_well, self.source_concentration)
@@ -267,8 +274,17 @@ class DilutionScheme(object):
         return transfers
 
     def _map_pair_and_transfers(self, pairs):
+        """
+        :param pairs: input artifact --- output artifact pair
+        :return: A function returning an artifact pair, given a transfer object
+        """
         pair_dict = {id(pair): pair for pair in pairs}
-        return {transfer: pair_dict[transfer.pair_id] for transfer in self.transfers}
+
+        def pair_by_transfer(transfer):
+            by_transfer_dict = {transfer.identifier: pair_dict[
+                transfer.pair_id] for transfer in self.transfers}
+            return by_transfer_dict[transfer.identifier]
+        return pair_by_transfer
 
     def calculate_transfer_volumes(self):
         # Handle volumes etc.

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -102,10 +102,10 @@ class SingleTransfer(object):
         self.target_aliquot_name = destination_endpoint.aliquot_name
 
     def __str__(self):
-        source = "source({}/{}, conc={})".format(self.source_container,
-                                                 self.source_well, self.source_concentration)
-        target = "target({}/{}, conc={}, vol={})".format(self.target_container, self.target_well,
-                                                         self.requested_concentration, self.requested_volume)
+        source = "source({}, conc={})".format(
+            self.source_well, self.source_concentration)
+        target = "target({}, conc={}, vol={})".format(self.target_well,
+                                                      self.requested_concentration, self.requested_volume)
         return "{} => {}".format(source, target)
 
     def __repr__(self):
@@ -226,7 +226,8 @@ class DilutionScheme(object):
         self.transfers = self._filtered_transfers(
             all_transfers=all_transfers, include_blanks=include_blanks)
 
-        self.aliquot_pair_by_transfer = self._map_pair_and_transfers(pairs=pairs)
+        self.aliquot_pair_by_transfer = self._map_pair_and_transfers(
+            pairs=pairs)
         self.robot_deck_positioner = RobotDeckPositioner(
             robot_name, self.transfers, container.size)
 

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -230,18 +230,19 @@ class DilutionScheme(object):
         container = pairs[0].output_artifact.container
         all_transfers = self._create_transfers(
             pairs, concentration_ref=concentration_ref)
-        self.transfers = self._filtered_transfers(
+        self._transfers = self._filtered_transfers(
             all_transfers=all_transfers, include_blanks=include_blanks)
 
         self.aliquot_pair_by_transfer = self._map_pair_and_transfers(
             pairs=pairs)
         self.robot_deck_positioner = RobotDeckPositioner(
-            robot_name, self.transfers, container.size)
+            robot_name, self._transfers, container.size)
 
         self.calculate_transfer_volumes()
-        self.transfers = self.split_up_high_volume_rows(self.transfers)
         self.do_positioning()
-        self.transfers = self.sort_transfers(self.transfers)
+        self.split_row_transfers = self.split_up_high_volume_rows(
+            self.sort_transfers(self._transfers))
+        self.unsplit_transfers = self.sort_transfers(self._transfers)
         self.grouped_transfers = list(self._grouped_transfers())
 
     def _grouped_transfers(self):
@@ -251,7 +252,7 @@ class DilutionScheme(object):
         :return: An iterable group of transfers for a common destination well.
         """
         for key, transfer_group in groupby(
-                self.transfers, key=lambda t: "{}{}".format(
+                self._transfers, key=lambda t: "{}{}".format(
                     t.target_container, t.target_well.position)):
             yield list(transfer_group)
 
@@ -282,14 +283,14 @@ class DilutionScheme(object):
 
         def pair_by_transfer(transfer):
             by_transfer_dict = {transfer.identifier: pair_dict[
-                transfer.pair_id] for transfer in self.transfers}
+                transfer.pair_id] for transfer in self._transfers}
             return by_transfer_dict[transfer.identifier]
         return pair_by_transfer
 
     def calculate_transfer_volumes(self):
         # Handle volumes etc.
         self.volume_calc_strategy.calculate_transfer_volumes(
-            transfers=self.transfers, scale_up_low_volumes=self.scale_up_low_volumes)
+            transfers=self._transfers, scale_up_low_volumes=self.scale_up_low_volumes)
 
     def split_up_high_volume_rows(self, transfers):
         """
@@ -389,7 +390,7 @@ class DilutionScheme(object):
 
     def do_positioning(self):
         # Handle positioning
-        for transfer in self.transfers:
+        for transfer in self._transfers:
             transfer.source_well_index = self.robot_deck_positioner.indexer(
                 transfer.source_well)
             transfer.source_plate_pos = self.robot_deck_positioner. \

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -239,9 +239,9 @@ class DilutionScheme(object):
             robot_name, self.transfers, container.size)
 
         self.calculate_transfer_volumes()
-        self.split_up_high_volume_rows()
+        self.transfers = self.split_up_high_volume_rows(self.transfers)
         self.do_positioning()
-        self.sort_transfers()
+        self.transfers = self.sort_transfers(self.transfers)
         self.grouped_transfers = list(self._grouped_transfers())
 
     def _grouped_transfers(self):
@@ -291,14 +291,14 @@ class DilutionScheme(object):
         self.volume_calc_strategy.calculate_transfer_volumes(
             transfers=self.transfers, scale_up_low_volumes=self.scale_up_low_volumes)
 
-    def split_up_high_volume_rows(self):
+    def split_up_high_volume_rows(self, transfers):
         """
         Split up a transfer between source well x and target well y into
         several rows, if sample volume or buffer volume exceeds 50 ul
         :return:
         """
-        added_transfers = []
-        for transfer in self.transfers:
+        split_row_transfers = []
+        for transfer in transfers:
             calculation_volume = max(
                 self._get_volume(transfer.sample_volume), self._get_volume(transfer.buffer_volume))
             (n, residual) = divmod(calculation_volume, PIPETTING_MAX_VOLUME)
@@ -308,24 +308,25 @@ class DilutionScheme(object):
                 total_rows = int(n)
 
             copies = self._create_copies(transfer, total_rows)
-            added_transfers += copies
+            split_row_transfers += copies
             self._split_up_volumes(
-                [transfer] + copies, transfer.sample_volume, transfer.buffer_volume)
+                copies, transfer.sample_volume, transfer.buffer_volume)
 
-        self.transfers += added_transfers
+        return split_row_transfers
 
     @staticmethod
     def _create_copies(transfer, total_rows):
         """
-        Create copies of transfer, if duplication_number > 1,
-        that will cause extra rows in the driver file.
+        Create copies of transfer
+        that will cause extra rows in the driver file if
+        pipetting volume exceeds 50 ul.
         Initiate both buffer volume and sample volume to zero
         :param transfer: The transfer to be copied
         :param total_rows: The total number of rows needed for a
         transfer between source well x and target well y
         :return:
         """
-        copies = []
+        copies = [copy.copy(transfer)]
         for i in xrange(0, total_rows - 1):
             t = copy.copy(transfer)
             t.buffer_volume = 0
@@ -360,22 +361,21 @@ class DilutionScheme(object):
                 t.sample_volume = float(
                     original_sample_volume / number_rows)
 
-    def sort_transfers(self):
+    def sort_transfers(self, transfers):
         def pipetting_volume(transfer):
             return self._get_volume(transfer.buffer_volume) + self._get_volume(transfer.sample_volume)
 
         def max_added_pip_volume():
             volumes = map(lambda t: (self._get_volume(t.buffer_volume),
-                                     self._get_volume(t.sample_volume)), self.transfers)
+                                     self._get_volume(t.sample_volume)), self._transfers)
             return max(map(lambda (buffer_vol, sample_vol): buffer_vol + sample_vol, volumes))
 
         # Sort on source position, and in case of splitted rows, pipetting
         # volumes. Let max pipetting volumes be shown first
         max_vol = max_added_pip_volume()
-        self.transfers = sorted(self.transfers,
-                                key=lambda t:
-                                self.robot_deck_positioner.find_sort_number(t) +
-                                (max_vol - pipetting_volume(t)) / (max_vol + 1.0))
+        return sorted(
+            transfers, key=lambda t: self.robot_deck_positioner.find_sort_number(t) +
+            (max_vol - pipetting_volume(t)) / (max_vol + 1.0))
 
     @staticmethod
     def _get_volume(volume):

--- a/clarity_ext/dilution.py
+++ b/clarity_ext/dilution.py
@@ -1,6 +1,5 @@
 import copy
 from clarity_ext.utils import get_and_apply
-from itertools import groupby
 from clarity_ext.dilution_strategies import *
 
 DILUTION_WASTE_VOLUME = 1
@@ -243,18 +242,6 @@ class DilutionScheme(object):
         self.split_row_transfers = self.split_up_high_volume_rows(
             self.sort_transfers(self._transfers))
         self.unsplit_transfers = self.sort_transfers(self._transfers)
-        self.grouped_transfers = list(self._grouped_transfers())
-
-    def _grouped_transfers(self):
-        """
-        Sometimes a sample transfer from source A to destination B is
-        split up on several rows, due to the max pipetting volume of 50 ul.
-        :return: An iterable group of transfers for a common destination well.
-        """
-        for key, transfer_group in groupby(
-                self._transfers, key=lambda t: "{}{}".format(
-                    t.target_container, t.target_well.position)):
-            yield list(transfer_group)
 
     def _filtered_transfers(self, all_transfers, include_blanks):
         if include_blanks:

--- a/test/unit/clarity_ext/dilution/test_dilutions.py
+++ b/test/unit/clarity_ext/dilution/test_dilutions.py
@@ -46,7 +46,7 @@ class TestDilutionScheme(unittest.TestCase):
              round(dilute.sample_volume, 1),
              round(dilute.buffer_volume, 1),
              dilute.target_well_index,
-             dilute.target_plate_pos] for dilute in dilution_scheme.transfers
+             dilute.target_plate_pos] for dilute in dilution_scheme.split_row_transfers
         ]
 
         validation_results = list(post_validate_dilution(dilution_scheme))
@@ -75,7 +75,7 @@ class TestDilutionScheme(unittest.TestCase):
              round(dilute.sample_volume, 1),
              round(dilute.buffer_volume, 1),
              dilute.target_well_index,
-             dilute.target_plate_pos] for dilute in dilution_scheme.transfers
+             dilute.target_plate_pos] for dilute in dilution_scheme.split_row_transfers
         ]
 
         validation_results = list(post_validate_dilution(dilution_scheme))
@@ -128,7 +128,7 @@ class TestDilutionScheme(unittest.TestCase):
              round(dilute.sample_volume, 1),
              round(dilute.buffer_volume, 1),
              dilute.target_well_index,
-             dilute.target_plate_pos] for dilute in dilution_scheme.transfers
+             dilute.target_plate_pos] for dilute in dilution_scheme.split_row_transfers
         ]
 
         # Assert:
@@ -179,16 +179,24 @@ class TestDilutionScheme(unittest.TestCase):
              round(dilute.sample_volume, 1),
              round(dilute.buffer_volume, 1),
              dilute.target_well_index,
-             dilute.target_plate_pos] for dilute in dilution_scheme.transfers
+             dilute.target_plate_pos] for dilute in dilution_scheme.split_row_transfers
         ]
-        self.assertEqual(dilution_scheme.transfers[0].has_to_evaporate, False)
-        self.assertEqual(dilution_scheme.transfers[1].has_to_evaporate, False)
-        self.assertEqual(dilution_scheme.transfers[2].has_to_evaporate, True)
-        self.assertEqual(dilution_scheme.transfers[3].has_to_evaporate, False)
-        self.assertEqual(dilution_scheme.transfers[0].scaled_up, True)
-        self.assertEqual(dilution_scheme.transfers[1].scaled_up, True)
-        self.assertEqual(dilution_scheme.transfers[2].scaled_up, True)
-        self.assertEqual(dilution_scheme.transfers[3].scaled_up, False)
+        self.assertEqual(dilution_scheme.split_row_transfers[
+                         0].has_to_evaporate, False)
+        self.assertEqual(dilution_scheme.split_row_transfers[
+                         1].has_to_evaporate, False)
+        self.assertEqual(dilution_scheme.split_row_transfers[
+                         2].has_to_evaporate, True)
+        self.assertEqual(dilution_scheme.split_row_transfers[
+                         3].has_to_evaporate, False)
+        self.assertEqual(dilution_scheme.split_row_transfers[
+                         0].scaled_up, True)
+        self.assertEqual(dilution_scheme.split_row_transfers[
+                         1].scaled_up, True)
+        self.assertEqual(dilution_scheme.split_row_transfers[
+                         2].scaled_up, True)
+        self.assertEqual(dilution_scheme.split_row_transfers[
+                         3].scaled_up, False)
         self.assertEqual(expected, actual)
 
     def test_split_rows_for_high_volume(self):
@@ -247,7 +255,7 @@ class TestDilutionScheme(unittest.TestCase):
              round(dilute.sample_volume, 1),
              round(dilute.buffer_volume, 1),
              dilute.target_well_index,
-             dilute.target_plate_pos] for dilute in dilution_scheme.transfers
+             dilute.target_plate_pos] for dilute in dilution_scheme.split_row_transfers
         ]
 
         print("actual:")
@@ -300,7 +308,7 @@ class TestDilutionScheme(unittest.TestCase):
              0,
              dilute.target_well_index,
              dilute.target_plate_pos,
-             ] for dilute in dilution_scheme.transfers
+             ] for dilute in dilution_scheme.split_row_transfers
         ]
 
         # Assert:
@@ -465,7 +473,7 @@ def pre_validate_dilution(dilution_scheme):
     Check that all pertinent variables are initiated so that calculations
     are possible to perform
     """
-    for transfer in dilution_scheme.transfers:
+    for transfer in dilution_scheme.unsplit_transfers:
         if not transfer.source_initial_volume:
             yield ValidationException("{}, source volume is not set.".format(transfer.aliquot_name))
         if not transfer.source_concentration:
@@ -483,18 +491,16 @@ def post_validate_dilution(dilution_scheme):
     def pos_str(transfer):
         return "{}=>{}".format(transfer.source_well, transfer.target_well)
 
-    for transfer_group in dilution_scheme.grouped_transfers:
-        total_volume = sum(map(lambda t: t.sample_volume + t.buffer_volume, transfer_group))
-
-        if total_volume > 100:
+    for t in dilution_scheme.unsplit_transfers:
+        if t.sample_volume + t.buffer_volume > 100:
             yield ValidationException("{}, too high destination volume ({}).".format(
-                transfer_group[0].aliquot_name, pos_str(transfer_group[0])))
-        if transfer_group[0].has_to_evaporate:
+                t.aliquot_name, pos_str(t)))
+        if t.has_to_evaporate:
             yield ValidationException("{}, sample has to be evaporated ({}).".format(
-                transfer_group[0].aliquot_name, pos_str(transfer_group[0])), ValidationType.WARNING)
-        if transfer_group[0].scaled_up:
+                t.aliquot_name, pos_str(t)), ValidationType.WARNING)
+        if t.scaled_up:
             yield ValidationException("{}, sample volume is scaled up due to pipetting min volume of 2 ul ({}).".format(
-                transfer_group[0].aliquot_name, pos_str(transfer_group[0])), ValidationType.WARNING)
+                t.aliquot_name, pos_str(t)), ValidationType.WARNING)
 
 
 if __name__ == "__main__":

--- a/test/unit/clarity_ext/dilution/test_pooling.py
+++ b/test/unit/clarity_ext/dilution/test_pooling.py
@@ -8,6 +8,7 @@ from clarity_ext.domain.validation import ValidationType
 from test.unit.clarity_ext.helpers import fake_analyte
 from test.unit.clarity_ext.helpers import print_list
 from test.unit.clarity_ext import helpers
+from itertools import groupby
 
 
 UDF_MAP = {
@@ -60,7 +61,7 @@ class TestLibraryPooling(unittest.TestCase):
              round(dilute.sample_volume, 1),
              round(dilute.buffer_volume, 1),
              dilute.target_well_index,
-             dilute.target_plate_pos] for dilute in dilution_scheme.transfers
+             dilute.target_plate_pos] for dilute in dilution_scheme.split_row_transfers
         ]
 
         validation_results = list(post_validate_dilution(dilution_scheme))
@@ -90,7 +91,7 @@ class TestLibraryPooling(unittest.TestCase):
              round(dilute.sample_volume, 1),
              round(dilute.buffer_volume, 1),
              dilute.target_well_index,
-             dilute.target_plate_pos] for dilute in dilution_scheme.transfers
+             dilute.target_plate_pos] for dilute in dilution_scheme.split_row_transfers
         ]
 
         validation_results = list(post_validate_dilution(dilution_scheme))
@@ -314,7 +315,7 @@ class TestLibraryPooling(unittest.TestCase):
             ["Warning: Pool1, volume has been scaled up due to the min pipetting volume of 2 ul (cont2(B4))."])
         self.assertEqual(expected, actual)
 
-    def test_scaled_up_and_splitted_rows(self):
+    def test_scaled_up_and_split_rows(self):
         def invalid_analyte_set():
             samples = ["sample1", "sample2", "sample3"]
             pool1 = fake_analyte("cont2", "art4", samples, "Pool1", "B:4",
@@ -367,7 +368,7 @@ class TestLibraryPooling(unittest.TestCase):
              round(dilute.sample_volume, 1),
              round(dilute.buffer_volume, 1),
              dilute.target_well_index,
-             dilute.target_plate_pos] for dilute in dilution_scheme.transfers
+             dilute.target_plate_pos] for dilute in dilution_scheme.split_row_transfers
         ]
 
         print_list(expected, "expected")
@@ -413,7 +414,7 @@ def pre_validate_dilution(dilution_scheme):
     Check that all pertinent variables are initiated so that calculations
     are possible to perform
     """
-    for transfer in dilution_scheme.transfers:
+    for transfer in dilution_scheme.unsplit_transfers:
         if not transfer.source_initial_volume:
             yield ValidationException("{}, source volume is not set.".format(transfer.aliquot_name))
         if not transfer.source_concentration:
@@ -427,10 +428,14 @@ def post_validate_dilution(dilution_scheme):
     def pos_str(transfer):
         return "{}".format(transfer.target_well)
 
-    for g in dilution_scheme.grouped_transfers:
-        total_volume = sum(map(lambda t: t.sample_volume +
-                               t.buffer_volume, g))
+    sorted_transfers = sorted(
+        dilution_scheme.unsplit_transfers, key=lambda t: t.target_aliquot_name)
+    grouped_transfers = groupby(
+        sorted_transfers, key=lambda t: t.target_aliquot_name)
 
+    for key, g in grouped_transfers:
+        g = list(g)
+        total_volume = sum(map(lambda t: t.sample_volume + t.buffer_volume, g))
         if total_volume > 100:
             yield ValidationException("{}, too high destination volume ({}).".format(
                 g[0].target_aliquot_name, pos_str(g[0])))

--- a/test/unit/clarity_ext/dilution/test_update_fields.py
+++ b/test/unit/clarity_ext/dilution/test_update_fields.py
@@ -38,9 +38,9 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
         aliquot_pair_by_transfer = dilution_scheme.aliquot_pair_by_transfer
         for transfer in dilution_scheme.transfers:
             # Make preparation, fetch the analyte to be updated
-            source_analyte = aliquot_pair_by_transfer[transfer].input_artifact
-            destination_analyte = aliquot_pair_by_transfer[
-                transfer].output_artifact
+            source_analyte = aliquot_pair_by_transfer(transfer).input_artifact
+            destination_analyte = aliquot_pair_by_transfer(
+                transfer).output_artifact
 
             # Update fields for analytes
             source_analyte.set_udf("volume", transfer.source_initial_volume -
@@ -64,8 +64,8 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
         self._update_fields(dilution_scheme, context)
         dilute = dilution_scheme.transfers[-1]
         expected = 29.0
-        outcome = dilution_scheme.aliquot_pair_by_transfer[
-            dilute].input_artifact.volume
+        outcome = dilution_scheme.aliquot_pair_by_transfer(
+            dilute).input_artifact.volume
         print(dilute.aliquot_name)
         self.assertEqual(expected, outcome)
 
@@ -75,8 +75,8 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
         self._update_fields(dilution_scheme, context)
         source_volume_sum = 0
         for dilute in dilution_scheme.transfers:
-            outcome = dilution_scheme.aliquot_pair_by_transfer[
-                dilute].input_artifact.volume
+            outcome = dilution_scheme.aliquot_pair_by_transfer(
+                dilute).input_artifact.volume
             source_volume_sum += outcome
         expected_sum = 57.0
         self.assertEqual(expected_sum, source_volume_sum)
@@ -87,7 +87,7 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
         self._update_fields(dilution_scheme, context)
         aliquot_pair_by_transfer = dilution_scheme.aliquot_pair_by_transfer
         for transfer in dilution_scheme.transfers:
-            source_aliquot = aliquot_pair_by_transfer[transfer].input_artifact
+            source_aliquot = aliquot_pair_by_transfer(transfer).input_artifact
             print("transfer sample name: {}".format(transfer.aliquot_name))
             print("source aliquot sample name: {}".format(source_aliquot.name))
             self.assertEqual(transfer.aliquot_name, source_aliquot.name)

--- a/test/unit/clarity_ext/dilution/test_update_fields.py
+++ b/test/unit/clarity_ext/dilution/test_update_fields.py
@@ -4,81 +4,148 @@ from mock import MagicMock
 from clarity_ext.dilution import DilutionScheme
 from clarity_ext.dilution import CONCENTRATION_REF_NGUL
 from clarity_ext.dilution import VOLUME_CALC_BY_CONC
+from clarity_ext.service.artifact_service import ArtifactService
+from clarity_ext.extensions import ExtensionContext
 from test.unit.clarity_ext import helpers
 from test.unit.clarity_ext.helpers import fake_analyte
+from test.unit.clarity_ext.helpers import mock_step_repository
+from test.unit.clarity_ext.helpers import mock_context
+from test.unit.clarity_ext.helpers import *
+
+UDF_MAP = {
+    "concentration_ngul": "conc",
+    "requested_concentration_ngul": "rconc",
+    "volume": "volume",
+}
 
 
 class UpdateFieldsForDilutionTests(unittest.TestCase):
 
-    def setUp(self):
-        self.dilution_scheme = None
+    def _init_dilution_scheme(self, concentration_ref, analyte_set=None):
+        def udf_adapted_analyte_set():
+            return analyte_set(udf_map=UDF_MAP)
 
-    def _init_dilution_scheme(self, concentration_ref):
-        svc = helpers.mock_artifact_service(analyte_set_with_blank)
-        self.dilution_scheme = DilutionScheme.create(
+        repo = mock_step_repository(analyte_set=udf_adapted_analyte_set)
+        svc = ArtifactService(step_repository=repo)
+        context = mock_context(artifact_service=svc, step_repo=repo)
+        dilution_scheme = DilutionScheme.create(
             artifact_service=svc, robot_name="Hamilton",
             concentration_ref=concentration_ref, volume_calc_method=VOLUME_CALC_BY_CONC)
 
-        analyte_pair_by_dilute = self.dilution_scheme.aliquot_pair_by_transfer
-        for dilute in self.dilution_scheme.transfers:
+        return dilution_scheme, context
+
+    def _update_fields(self, dilution_scheme, context):
+        analyte_pair_by_dilute = dilution_scheme.aliquot_pair_by_transfer
+        for dilute in dilution_scheme.transfers:
             # Make preparation, fetch the analyte to be updated
             source_analyte = analyte_pair_by_dilute[dilute].input_artifact
             destination_analyte = analyte_pair_by_dilute[
                 dilute].output_artifact
 
             # Update fields for analytes
-            source_analyte.volume = dilute.source_initial_volume - \
-                dilute.requested_volume - DILUTION_WASTE_VOLUME
+            source_analyte.set_udf("volume", dilute.source_initial_volume -
+                                   dilute.sample_volume - DILUTION_WASTE_VOLUME)
 
-            destination_analyte.concentration = dilute.requested_concentration
+            destination_analyte.set_udf("conc", dilute.sample_volume *
+                                        dilute.source_concentration /
+                                        (dilute.sample_volume + dilute.buffer_volume))
 
-            destination_analyte.volume = dilute.requested_volume
+            destination_analyte.set_udf(
+                "volume", dilute.sample_volume + dilute.buffer_volume)
+
+            context.update(source_analyte)
+            context.update(destination_analyte)
+
+        context.commit()
 
     def test_source_volume_update_1(self):
-        self._init_dilution_scheme(concentration_ref=CONCENTRATION_REF_NGUL)
-        dilute = self.dilution_scheme.transfers[-1]
+        dilution_scheme, context = self._init_dilution_scheme(
+            concentration_ref=CONCENTRATION_REF_NGUL, analyte_set=analyte_set_with_blank)
+        self._update_fields(dilution_scheme, context)
+        dilute = dilution_scheme.transfers[-1]
         expected = 29.0
-        outcome = self.dilution_scheme.aliquot_pair_by_transfer[
+        outcome = dilution_scheme.aliquot_pair_by_transfer[
             dilute].input_artifact.volume
         print(dilute.aliquot_name)
         self.assertEqual(expected, outcome)
 
     def test_source_volume_update_all(self):
-        self._init_dilution_scheme(concentration_ref=CONCENTRATION_REF_NGUL)
+        dilution_scheme, context = self._init_dilution_scheme(
+            concentration_ref=CONCENTRATION_REF_NGUL, analyte_set=analyte_set_with_blank)
+        self._update_fields(dilution_scheme, context)
         source_volume_sum = 0
-        for dilute in self.dilution_scheme.transfers:
-            outcome = self.dilution_scheme.aliquot_pair_by_transfer[
+        for dilute in dilution_scheme.transfers:
+            outcome = dilution_scheme.aliquot_pair_by_transfer[
                 dilute].input_artifact.volume
             source_volume_sum += outcome
         expected_sum = 57.0
         self.assertEqual(expected_sum, source_volume_sum)
 
     def test_dilute_aliqout_matching(self):
-        self._init_dilution_scheme(concentration_ref=CONCENTRATION_REF_NGUL)
-        aliquot_pair_by_transfer = self.dilution_scheme.aliquot_pair_by_transfer
-        for transfer in self.dilution_scheme.transfers:
+        dilution_scheme, context = self._init_dilution_scheme(
+            concentration_ref=CONCENTRATION_REF_NGUL, analyte_set=analyte_set_with_blank)
+        self._update_fields(dilution_scheme, context)
+        aliquot_pair_by_transfer = dilution_scheme.aliquot_pair_by_transfer
+        for transfer in dilution_scheme.transfers:
             source_aliquot = aliquot_pair_by_transfer[transfer].input_artifact
             print("transfer sample name: {}".format(transfer.aliquot_name))
             print("source aliquot sample name: {}".format(source_aliquot.name))
             self.assertEqual(transfer.aliquot_name, source_aliquot.name)
 
+    def test_update_base(self):
+        dilution_scheme, context = self._init_dilution_scheme(
+            concentration_ref=CONCENTRATION_REF_NGUL, analyte_set=analyte_set_with_blank)
 
-def analyte_set_with_blank():
+        self._update_fields(dilution_scheme, context)
+        actual = context.response
+        expected = [
+            ("Analyte", "art1", "volume", "9.0"),
+            ("Analyte", "art2", "volume", "20.0"),
+            ("Analyte", "art2", "conc", "100.0"),
+            ("Analyte", "art3", "volume", "19.0"),
+            ("Analyte", "art4", "volume", "20.0"),
+            ("Analyte", "art4", "conc", "100.0"),
+            ("Analyte", "art5", "volume", "29.0"),
+            ("Analyte", "art6", "volume", "20.0"),
+            ("Analyte", "art6", "conc", "100.0"),
+        ]
+
+        self.assertEqual(expected, actual)
+
+        # cache = repo.orig_state_cache
+        # print_out_dict([cache[art] for art in cache if cache[art].name == "sample1"], "orig state cache")
+        #
+        # print_out_dict([a for a in context._update_queue if a.name == "sample1"], "updated analytes")
+
+        self.assertEqual(expected, actual)
+
+
+def analyte_set_with_blank(udf_map=None):
+    api_resource = MagicMock()
+    api_resource.udf = {}
     return [
-        (fake_analyte("cont1", "art7", "sample4", "sample4", "E:2", True, is_control=True),
+        (fake_analyte("cont1", "art7", "sample4", "sample4", "E:2", True, is_control=True,
+                      udf_map=udf_map, api_resource=api_resource),
          fake_analyte("cont2", "art8", "sample4", "sample4", "E:2", False, is_control=True,
-                      requested_concentration=100, requested_volume=20)),
+                      udf_map=udf_map, api_resource=api_resource,
+                      requested_concentration_ngul=100, requested_volume=20)),
         (fake_analyte("cont1", "art1", "sample1", "sample1", "B:2", True,
-                      concentration=100, volume=30),
+                      udf_map=udf_map, api_resource=api_resource,
+                      concentration_ngul=100, volume=30),
          fake_analyte("cont2", "art2", "sample1", "sample1", "B:2", False,
-                      requested_concentration=100, requested_volume=20)),
+                      udf_map=udf_map, api_resource=api_resource,
+                      requested_concentration_ngul=100, requested_volume=20)),
         (fake_analyte("cont1", "art3", "sample2", "sample2", "C:2", True,
-                      concentration=100, volume=40),
+                      udf_map=udf_map, api_resource=api_resource,
+                      concentration_ngul=100, volume=40),
          fake_analyte("cont2", "art4", "sample2", "sample2", "C:2", False,
-                      requested_concentration=100, requested_volume=20)),
+                      udf_map=udf_map, api_resource=api_resource,
+                      requested_concentration_ngul=100, requested_volume=20)),
         (fake_analyte("cont1", "art5", "sample3", "sample3", "D:2", True,
-                      concentration=100, volume=50),
+                      udf_map=udf_map, api_resource=api_resource,
+                      concentration_ngul=100, volume=50),
          fake_analyte("cont2", "art6", "sample3", "sample3", "D:2", False,
-                      requested_concentration=100, requested_volume=20)),
+                      udf_map=udf_map, api_resource=api_resource,
+                      requested_concentration_ngul=100, requested_volume=20)),
     ]
 

--- a/test/unit/clarity_ext/dilution/test_update_fields.py
+++ b/test/unit/clarity_ext/dilution/test_update_fields.py
@@ -35,23 +35,23 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
         return dilution_scheme, context
 
     def _update_fields(self, dilution_scheme, context):
-        analyte_pair_by_dilute = dilution_scheme.aliquot_pair_by_transfer
-        for dilute in dilution_scheme.transfers:
+        aliquot_pair_by_transfer = dilution_scheme.aliquot_pair_by_transfer
+        for transfer in dilution_scheme.transfers:
             # Make preparation, fetch the analyte to be updated
-            source_analyte = analyte_pair_by_dilute[dilute].input_artifact
-            destination_analyte = analyte_pair_by_dilute[
-                dilute].output_artifact
+            source_analyte = aliquot_pair_by_transfer[transfer].input_artifact
+            destination_analyte = aliquot_pair_by_transfer[
+                transfer].output_artifact
 
             # Update fields for analytes
-            source_analyte.set_udf("volume", dilute.source_initial_volume -
-                                   dilute.sample_volume - DILUTION_WASTE_VOLUME)
+            source_analyte.set_udf("volume", transfer.source_initial_volume -
+                                   transfer.sample_volume - DILUTION_WASTE_VOLUME)
 
-            destination_analyte.set_udf("conc", dilute.sample_volume *
-                                        dilute.source_concentration /
-                                        (dilute.sample_volume + dilute.buffer_volume))
+            destination_analyte.set_udf("conc", transfer.sample_volume *
+                                        transfer.source_concentration /
+                                        (transfer.sample_volume + transfer.buffer_volume))
 
             destination_analyte.set_udf(
-                "volume", dilute.sample_volume + dilute.buffer_volume)
+                "volume", transfer.sample_volume + transfer.buffer_volume)
 
             context.update(source_analyte)
             context.update(destination_analyte)

--- a/test/unit/clarity_ext/dilution/test_update_fields.py
+++ b/test/unit/clarity_ext/dilution/test_update_fields.py
@@ -36,15 +36,15 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
 
     def _update_fields(self, dilution_scheme, context):
         aliquot_pair_by_transfer = dilution_scheme.aliquot_pair_by_transfer
-        for transfer in dilution_scheme.transfers:
+        for transfer in dilution_scheme.unsplit_transfers:
             # Make preparation, fetch the analyte to be updated
             source_analyte = aliquot_pair_by_transfer(transfer).input_artifact
             destination_analyte = aliquot_pair_by_transfer(
                 transfer).output_artifact
 
             # Update fields for analytes
-            source_analyte.set_udf("volume", transfer.source_initial_volume -
-                                   transfer.sample_volume - DILUTION_WASTE_VOLUME)
+            source_analyte.set_udf("volume", max(
+                transfer.source_initial_volume - transfer.sample_volume - DILUTION_WASTE_VOLUME, 0))
 
             destination_analyte.set_udf("conc", transfer.sample_volume *
                                         transfer.source_concentration /
@@ -62,7 +62,7 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
         dilution_scheme, context = self._init_dilution_scheme(
             concentration_ref=CONCENTRATION_REF_NGUL, analyte_set=analyte_set_with_blank)
         self._update_fields(dilution_scheme, context)
-        dilute = dilution_scheme.transfers[-1]
+        dilute = dilution_scheme.unsplit_transfers[-1]
         expected = 29.0
         outcome = dilution_scheme.aliquot_pair_by_transfer(
             dilute).input_artifact.volume
@@ -74,7 +74,7 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
             concentration_ref=CONCENTRATION_REF_NGUL, analyte_set=analyte_set_with_blank)
         self._update_fields(dilution_scheme, context)
         source_volume_sum = 0
-        for dilute in dilution_scheme.transfers:
+        for dilute in dilution_scheme.unsplit_transfers:
             outcome = dilution_scheme.aliquot_pair_by_transfer(
                 dilute).input_artifact.volume
             source_volume_sum += outcome
@@ -86,7 +86,7 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
             concentration_ref=CONCENTRATION_REF_NGUL, analyte_set=analyte_set_with_blank)
         self._update_fields(dilution_scheme, context)
         aliquot_pair_by_transfer = dilution_scheme.aliquot_pair_by_transfer
-        for transfer in dilution_scheme.transfers:
+        for transfer in dilution_scheme.unsplit_transfers:
             source_aliquot = aliquot_pair_by_transfer(transfer).input_artifact
             print("transfer sample name: {}".format(transfer.aliquot_name))
             print("source aliquot sample name: {}".format(source_aliquot.name))
@@ -112,10 +112,42 @@ class UpdateFieldsForDilutionTests(unittest.TestCase):
 
         self.assertEqual(expected, actual)
 
+    def test_update_split_rows(self):
+        def analyte_set_split_rows(udf_map=None):
+            api_resource = MagicMock()
+            api_resource.udf = {}
+            return [
+                (fake_analyte("cont1", "art7", "sample4", "sample4", "E:2", True, is_control=True,
+                              udf_map=udf_map, api_resource=api_resource),
+                 fake_analyte("cont2", "art8", "sample4", "sample4", "E:2", False, is_control=True,
+                              udf_map=udf_map, api_resource=api_resource,
+                              requested_concentration_ngul=100, requested_volume=20)),
+                (fake_analyte("cont1", "art1", "sample1", "sample1", "B:2", True,
+                              udf_map=udf_map, api_resource=api_resource,
+                              concentration_ngul=100, volume=30),
+                 fake_analyte("cont2", "art2", "sample1", "sample1", "B:2", False,
+                              udf_map=udf_map, api_resource=api_resource,
+                              requested_concentration_ngul=100, requested_volume=70)),
+            ]
+
+        dilution_scheme, context = self._init_dilution_scheme(
+            concentration_ref=CONCENTRATION_REF_NGUL, analyte_set=analyte_set_split_rows)
+        self._update_fields(dilution_scheme, context)
+
+        actual = context.response
+        expected = [
+            ("Analyte", "art1", "volume", "0"),
+            ("Analyte", "art2", "volume", "70.0"),
+            ("Analyte", "art2", "conc", "100.0"),
+        ]
+
+        # repo = context.artifact_service.step_repository
         # cache = repo.orig_state_cache
         # print_out_dict([cache[art] for art in cache if cache[art].name == "sample1"], "orig state cache")
         #
         # print_out_dict([a for a in context._update_queue if a.name == "sample1"], "updated analytes")
+
+        print_list(actual, "actual:")
 
         self.assertEqual(expected, actual)
 

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -3,6 +3,8 @@ from mock import MagicMock
 from mock import patch
 from mock import PropertyMock
 from clarity_ext.service import ArtifactService, FileService
+from clarity_ext.repository.step_repository import StepRepository
+from clarity_ext.context import ExtensionContext
 from clarity_ext.domain.analyte import Analyte
 from clarity_ext.domain.container import Well
 from clarity_ext.domain.container import ContainerPosition
@@ -116,6 +118,32 @@ def mock_artifact_service(artifact_set):
     repo.all_artifacts = artifact_set
     svc = ArtifactService(repo)
     return svc
+
+
+def mock_step_repository(analyte_set):
+    """
+    To be able to achieve a response matrix containing
+    updates from update_artifacts()
+    :param analyte_set:
+    :return:
+    """
+    session = MagicMock()
+    session.api = MagicMock()
+    step_repo = StepRepository(session=session)
+    step_repo.all_artifacts = analyte_set
+    step_repo._add_to_orig_state_cache(analyte_set())
+    return step_repo
+
+
+def mock_context(artifact_service=None, step_repo=None):
+    session = MagicMock()
+    file_service = MagicMock()
+    current_user = MagicMock()
+    step_logger_service = MagicMock()
+    return ExtensionContext(session=session, artifact_service=artifact_service,
+                            file_service=file_service,
+                            current_user=current_user, step_logger_service=step_logger_service,
+                            step_repo=step_repo)
 
 
 def mock_file_service(artifact_set):


### PR DESCRIPTION
Update fields was previously not implemented (as I remember it)

Use two list variables holding transfers, replacing  the former self.transfers: 
self.split_row_transfers, any row containing more than 50 ul transfer volume is split up. This list is used when producing driver file. 
self.unsplit_transfers. This list is used when updating fields. 

Not yet validated:
* updating volume for samples that are scaled up (original pipetting volume was less than 2 ul)
* updating volume for samples that are evaporated. 