### PR TITLE
Start porting to ClarityMapper

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -8,6 +8,7 @@ from clarity_ext.service import (ArtifactService, FileService, StepLoggerService
 from clarity_ext.repository import StepRepository
 from clarity_ext import utils
 from clarity_ext.service.file_service import OSService
+from clarity_ext.mappers.clarity_mapper import ClarityMapper
 
 
 class ExtensionContext(object):
@@ -73,16 +74,19 @@ class ExtensionContext(object):
         use the constructor for custom use and unit tests.
         """
         session = ClaritySession.create(step_id)
-        step_repo = StepRepository(session)
+        clarity_mapper = ClarityMapper()
+        step_repo = StepRepository(session, clarity_mapper)
         artifact_service = ArtifactService(step_repo)
         current_user = step_repo.current_user()
         file_repository = FileRepository(session)
-        file_service = FileService(artifact_service, file_repository, False, OSService())
+        file_service = FileService(
+            artifact_service, file_repository, False, OSService())
         step_logger_service = StepLoggerService("Step log", file_service)
         validation_service = ValidationService(step_logger_service)
-        clarity_service = ClarityService(ClarityRepository(), step_repo)
-        dilution_service = DilutionService(validation_service)
+        clarity_service = ClarityService(
+            ClarityRepository(), step_repo, clarity_mapper)
         process_service = ProcessService()
+        dilution_service = DilutionService(validation_service)
         upload_file_service = UploadFileService(OSService(), artifact_service,
                                                 uploaded_to_stdout=uploaded_to_stdout,
                                                 disable_commits=not upload_files)

--- a/clarity_ext/domain/aliquot.py
+++ b/clarity_ext/domain/aliquot.py
@@ -1,6 +1,5 @@
 from clarity_ext.domain.artifact import Artifact
-from clarity_ext.domain.udf import DomainObjectMixin, DomainObjectWithUdfMixin
-from clarity_ext.domain.container import ContainerPosition
+from clarity_ext.domain.udf import DomainObjectWithUdfMixin
 
 
 class Aliquot(Artifact):
@@ -23,49 +22,23 @@ class Aliquot(Artifact):
             self.container = None
         self.is_from_original = False
 
-    @staticmethod
-    def create_well_from_rest(resource, container_repo):
-        # TODO: Batch call
-        try:
-            container = container_repo.get_container(resource.location[0])
-        except AttributeError:
-            pass
-            container = None
-        try:
-            pos = ContainerPosition.create(resource.location[1])
-        except (AttributeError, ValueError):
-            pass
-            pos = None
-
-        well = None
-        if container and pos:
-            well = container.wells[pos]
-
-        return well
-
 
 class Sample(DomainObjectWithUdfMixin):
 
-    def __init__(self, sample_id, name, project, udfs=None):
+    def __init__(self, sample_id, name, project, udf_map=None):
         """
         :param sample_id: The ID of the sample
         :param name: The name of the sample
         :param project: The project domain object
-        :param udfs: A dictionary of udfs
+        :param udf_map: An UdfMapping
         """
-        super(Sample, self).__init__(udfs)
+        super(Sample, self).__init__(udf_map=udf_map)
         self.id = sample_id
         self.name = name
         self.project = project
 
     def __repr__(self):
         return "<Sample id={}>".format(self.id)
-
-    @staticmethod
-    def create_from_rest_resource(resource):
-        project = Project(resource.project.name) if resource.project else None
-        sample = Sample(resource.id, resource.name, project, resource.udf)
-        return sample
 
 
 class Project(DomainObjectWithUdfMixin):

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -28,55 +28,6 @@ class Analyte(Aliquot):
             typename = ("Input" if self.is_input else "Output") + typename
         return "{}<{} ({})>".format(typename, self.name, self.id)
 
-    @staticmethod
-    def create_from_rest_resource(resource, is_input, container_repo, process_type):
-        """
-        Creates an Analyte from the rest resource. By default, the container
-        is created from the related container resource, except if one
-        already exists in the container map. This way, there will be created
-        only one container object for each id
-        """
-        # Map UDFs (which may be using different names in different Clarity setups)
-        # to a key-value list with well-defined key names:
-
-        udfs = None
-        if not is_input:
-            per_input_analytes = [process_output for process_output
-                                  in process_type.process_outputs
-                                  if process_output.output_generation_type == "PerInput" and
-                                  process_output.artifact_type == "Analyte"]
-            process_output = utils.single_or_default(per_input_analytes)
-            if process_output:
-                udfs = UdfMapping.expand_udfs(resource, process_output)
-
-        if udfs is None:
-            udfs = resource.udf
-
-        udf_map = UdfMapping(udfs)
-
-        well = Aliquot.create_well_from_rest(
-            resource=resource, container_repo=container_repo)
-
-        # TODO: sample should be put in a lazy property, and all samples in a step should be
-        # loaded in one batch
-        samples = [Sample.create_from_rest_resource(sample) for sample in resource.samples]
-
-        is_control = False
-        # TODO: This code principally belongs to the genologics layer, but 'control-type' does not exist there
-        if resource.root.find("control-type") is not None:
-            is_control = True
-        # TODO: A better way to decide if analyte is output of a previous step?
-        is_from_original = (resource.id.find("2-") != 0)
-        analyte = Analyte(api_resource=resource, is_input=is_input, id=resource.id,
-                          samples=samples, name=resource.name,
-                          well=well, is_control=is_control,
-                          udf_map=udf_map,
-                          is_from_original=is_from_original)
-        analyte.api_resource = resource
-        analyte.reagent_labels = resource.reagent_labels
-
-        return analyte
-
     @property
     def sample(self):
         """

--- a/clarity_ext/domain/result_file.py
+++ b/clarity_ext/domain/result_file.py
@@ -21,31 +21,6 @@ class ResultFile(Aliquot):
                 samples=samples, name=name, well=well, udf_map=udf_map)
         self.is_control = False
 
-    @staticmethod
-    def create_from_rest_resource(resource, is_input, container_repo, process_type):
-        """
-        Creates a `ResultFile` from the REST resource object.
-        The container is fetched from the container_repo.
-        """
-        if not is_input:
-            # We expect the process_type to define one PerInput ResultFile
-            process_output = utils.single([process_output for process_output in process_type.process_outputs
-                                           if process_output.output_generation_type == "PerInput" and
-                                           process_output.artifact_type == "ResultFile"])
-        udfs = UdfMapping.expand_udfs(resource, process_output)
-        udf_map = UdfMapping(udfs)
-
-        well = Aliquot.create_well_from_rest(
-            resource=resource, container_repo=container_repo)
-
-        # TODO: sample should be put in a lazy property, and all samples in a step should be
-        # loaded in one batch
-        samples = [Sample.create_from_rest_resource(sample) for sample in resource.samples]
-        ret = ResultFile(api_resource=resource, is_input=is_input,
-                         id=resource.id, samples=samples, name=resource.name, well=well,
-                         udf_map=udf_map)
-        return ret
-
     @property
     def sample(self):
         """Convenience property for fetching a single sample when only one is expected"""

--- a/clarity_ext/mappers/clarity_mapper.py
+++ b/clarity_ext/mappers/clarity_mapper.py
@@ -1,0 +1,171 @@
+from clarity_ext.domain.udf import UdfMapping
+from clarity_ext.domain.aliquot import Project, Sample
+from clarity_ext.domain import ResultFile
+from clarity_ext.domain import Analyte
+from clarity_ext import utils
+from clarity_ext.domain.container import ContainerPosition
+
+
+class ClarityMapper(object):
+    """
+    Maps Clarity API resources to/from internal domain objects.
+
+    Using a mapper to map between the two domains ensures that the code can stay independent from
+    Clarity. This helps in tests as well as by moving logic to other backends if required.
+
+    NOTE:
+    Limitation: The API resources should be built from domain objects, but currently, the mapper relies on
+    an internal cache, where the API resources are built based on the original values fetched from the API.
+    This may severely limit the usability in some cases, e.g. making it impossible to get a resource from a copy
+    of a domain object.
+
+    Temporary: Doesn't support all domain objects. Port the factory methods on the domain objects here.
+    """
+
+    def __init__(self):
+        self.map = dict()
+        # TODO: The container_repo used here could be reused per the lifetime of the mapper instead, and not
+        # passed around.
+        self.create_resource_by_type = {
+            Sample: self.sample_create_resource
+        }
+
+    def _after_object_created(self, domain_object, resource):
+        # See NOTE above. This mapping is only required while we're still not building the rest resources
+        # directly from the domain objects.
+        self.map[domain_object] = resource
+
+    def _get_from_cache(self, domain_object):
+        if domain_object not in self.map:
+            raise Exception("The domain object was not created via the mapper. In this implementation "
+                            "resources can only be fetched from the mapper if the object was created via the mapper.")
+        return self.map[domain_object]
+
+    def sample_create_object(self, resource):
+        project = Project(resource.project.name) if resource.project else None
+        udf_map = UdfMapping(resource.udf)
+        sample = Sample(resource.id, resource.name, project, udf_map)
+        self._after_object_created(sample, resource)
+        return sample
+
+    def create_resource(self, domain_object):
+        return self.create_resource_by_type[type(domain_object)](domain_object)
+
+    def sample_create_resource(self, sample):
+        # TODO: Every domain object should be able to report on changed fields. Use those to reconstruct
+        # the object
+        resource = self._get_from_cache(sample)
+
+        # TODO: Currently only fetching changed UDFs. Change the domain objects so they can report
+        # any changed field.
+        self._update_udfs(sample, resource)
+        return resource
+
+    def _update_udfs(self, domain_object, resource):
+        updated_fields = list(domain_object.udf_map.enumerate_updated())
+        print updated_fields
+
+        if len(updated_fields) == 0:
+            return None
+        else:
+            for udf_info in updated_fields:
+                resource.udf[udf_info.key] = udf_info.value
+            return resource
+
+    def analyte_create_object(self, resource, is_input, container_repo, process_type):
+        """
+        Creates an Analyte from the rest resource. By default, the container
+        is created from the related container resource, except if one
+        already exists in the container map. This way, there will be created
+        only one container object for each id
+        """
+        # Map UDFs (which may be using different names in different Clarity setups)
+        # to a key-value list with well-defined key names:
+
+        udfs = None
+        if not is_input:
+            per_input_analytes = [process_output for process_output
+                                  in process_type.process_outputs
+                                  if process_output.output_generation_type == "PerInput" and
+                                  process_output.artifact_type == "Analyte"]
+            process_output = utils.single_or_default(per_input_analytes)
+            if process_output:
+                udfs = UdfMapping.expand_udfs(resource, process_output)
+
+        if udfs is None:
+            udfs = resource.udf
+
+        udf_map = UdfMapping(udfs)
+
+        well = self.well_create_object(resource, container_repo)
+
+        # TODO: sample should be put in a lazy property, and all samples in a step should be
+        # loaded in one batch
+        samples = [self.sample_create_object(
+            sample) for sample in resource.samples]
+
+        is_control = False
+        # TODO: This code principally belongs to the genologics layer, but
+        # 'control-type' does not exist there
+        if resource.root.find("control-type") is not None:
+            is_control = True
+        # TODO: A better way to decide if analyte is output of a previous step?
+        is_from_original = (resource.id.find("2-") != 0)
+        analyte = Analyte(api_resource=resource, is_input=is_input, id=resource.id,
+                          samples=samples, name=resource.name,
+                          well=well, is_control=is_control,
+                          udf_map=udf_map,
+                          is_from_original=is_from_original)
+        analyte.api_resource = resource
+        analyte.reagent_labels = resource.reagent_labels
+        self._after_object_created(analyte, resource)
+        return analyte
+
+    def analyte_create_resource(self, analyte):
+        pass
+
+    def well_create_object(self, resource, container_repo):
+        # TODO: Batch call
+        try:
+            container = container_repo.get_container(resource.location[0])
+        except AttributeError:
+            pass
+            container = None
+        try:
+            pos = ContainerPosition.create(resource.location[1])
+        except (AttributeError, ValueError):
+            pass
+            pos = None
+
+        well = None
+        if container and pos:
+            well = container.wells[pos]
+
+        return well
+
+    def well_create_resource(self, well):
+        pass
+
+    def result_file_create_object(self, resource, is_input, container_repo, process_type):
+        """
+        Creates a `ResultFile` from the REST resource object.
+        The container is fetched from the container_repo.
+        """
+        if not is_input:
+            # We expect the process_type to define one PerInput ResultFile
+            process_output = utils.single([process_output for process_output in process_type.process_outputs
+                                           if process_output.output_generation_type == "PerInput" and
+                                           process_output.artifact_type == "ResultFile"])
+        udfs = UdfMapping.expand_udfs(resource, process_output)
+        udf_map = UdfMapping(udfs)
+
+        well = self.well_create_object(resource, container_repo)
+
+        # TODO: sample should be put in a lazy property, and all samples in a step should be
+        # loaded in one batch
+        samples = [self.sample_create_object(
+            sample) for sample in resource.samples]
+        ret = ResultFile(api_resource=resource, is_input=is_input,
+                         id=resource.id, samples=samples, name=resource.name, well=well,
+                         udf_map=udf_map)
+        return ret

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -5,7 +5,6 @@ from clarity_ext.domain.shared_result_file import SharedResultFile
 from clarity_ext.repository.container_repository import ContainerRepository
 from clarity_ext.domain.user import User
 from clarity_ext.domain import ProcessType
-import copy
 
 
 class StepRepository(object):
@@ -18,13 +17,15 @@ class StepRepository(object):
     to do that.
     """
 
-    def __init__(self, session):
+    def __init__(self, session, clarity_mapper):
         """
         Creates a new StepRepository
 
         :param session: A session object for connecting to Clarity
         """
         self.session = session
+        self.clarity_mapper = clarity_mapper
+
 
     def all_artifacts(self):
         """
@@ -114,9 +115,11 @@ class StepRepository(object):
         convenient methods for working with the domain object in extensions.
         """
         if artifact.type == "Analyte":
-            wrapped = Analyte.create_from_rest_resource(artifact, is_input, container_repo, process_type)
+            wrapped = self.clarity_mapper.analyte_create_object(
+                artifact, is_input, container_repo, process_type)
         elif artifact.type == "ResultFile" and gen_type == "PerInput":
-            wrapped = ResultFile.create_from_rest_resource(artifact, is_input, container_repo, process_type)
+            wrapped = self.clarity_mapper.result_file_create_object(
+                artifact, is_input, container_repo, process_type)
         elif artifact.type == "ResultFile" and gen_type == "PerAllInputs":
             wrapped = SharedResultFile.create_from_rest_resource(artifact, process_type)
         else:

--- a/clarity_ext/service/artifact_service.py
+++ b/clarity_ext/service/artifact_service.py
@@ -139,7 +139,8 @@ class ArtifactService:
         for process in parent_processes:
             # This might seem roundabout, but for simplicity, we create another artifact service for
             # fetching the parent items:
-            parent_step_repo = StepRepository(ClaritySession.create(process.id))
+            parent_step_repo = StepRepository(ClaritySession.create(process.id),
+                                              self.step_repository.clarity_mapper)
             parent_artifact_service = ArtifactService(parent_step_repo)
             for input in parent_artifact_service.all_input_artifacts():
                 yield input

--- a/test/integration/clarity_steps.yml
+++ b/test/integration/clarity_steps.yml
@@ -8,7 +8,7 @@ steps:
     description: >
         The output container has one patterned flow cell and there should be >= 2 samples
         which have related input artifacts in the parent process which have the same name.
-    pid: 24-9186
+    pid: 24-9935
     containers:
       - type: "Patterned Flow Cell"
 

--- a/test/integration/domain/test_artifact.py
+++ b/test/integration/domain/test_artifact.py
@@ -1,7 +1,6 @@
 import unittest
-from clarity_ext.repository import StepRepository
-from clarity_ext.clarity import ClaritySession
 from clarity_ext.domain import Analyte
+from clarity_ext.context import ExtensionContext
 import itertools
 
 
@@ -24,10 +23,9 @@ class TestIntegrationAnalyteRepository(unittest.TestCase):
             - Plate1: B5, D6
             - Plate2: A3, E9
         """
-        session = ClaritySession.create("24-3643")
-        repo = StepRepository(session)
+        context = ExtensionContext.create("24-3643")
         pairs = filter(lambda pair: isinstance(pair[0], Analyte) and
-                       isinstance(pair[1], Analyte), repo.all_artifacts())
+                       isinstance(pair[1], Analyte), context.step_repo.all_artifacts())
         # Of all the artifacts, we're only going to examine those that map from analytes
         # to analytes:
 

--- a/test/integration/domain/test_result_file.py
+++ b/test/integration/domain/test_result_file.py
@@ -1,5 +1,5 @@
 import unittest
-from clarity_ext.domain import Container
+from clarity_ext.domain import Container, ResultFile
 from clarity_ext.context import ExtensionContext
 import os
 
@@ -44,17 +44,17 @@ class TestIntegrationAnalyteRepository(unittest.TestCase):
     def test_can_fetch_all_output_files(self):
         """Can fetch all output files in a step"""
         context = ExtensionContext.create("24-3144")
+        # This will return output result files per input, not those per all
+        # inputs
         actual = set(f.id for f in context.output_result_files)
-        expected = set(['92-5244', '92-5245', '92-5246',
-                        '92-5241', '92-5242', '92-5243'])
+        expected = set(['92-5241', '92-5242'])
         self.assertEqual(expected, actual)
 
     def test_can_fetch_single_output_file(self):
         context = ExtensionContext.create("24-3144")
-        result = context.output_result_file_by_id("92-5244")
+        result = context.output_result_file_by_id("92-5242")
         self.assertIsNotNone(result)
-        # TODO: Assert fails, needs cleanup (ticket created)
-        #self.assertIsInstance(result, ResultFile)
+        self.assertIsInstance(result, ResultFile)
 
     @unittest.skip("Step removed")
     def test_can_read_xml(self):

--- a/test/unit/clarity_ext/domain/test_artifact.py
+++ b/test/unit/clarity_ext/domain/test_artifact.py
@@ -5,11 +5,11 @@ from test.unit.clarity_ext.helpers import fake_container
 from mock import MagicMock
 from clarity_ext.unit_conversion import UnitConversion
 from clarity_ext.domain import Artifact
-from clarity_ext.domain.analyte import Analyte
 from clarity_ext.domain.result_file import ResultFile
 from clarity_ext.domain.shared_result_file import SharedResultFile
 from test.unit.clarity_ext.helpers import mock_artifact_resource
 from test.unit.clarity_ext.helpers import mock_container_repo
+from clarity_ext.mappers.clarity_mapper import ClarityMapper
 
 
 class TestArtifact(unittest.TestCase):
@@ -79,9 +79,9 @@ class TestArtifact(unittest.TestCase):
         container = fake_container("cont1")
         container_repo.get_container.return_value = container
 
-        analyte = Analyte.create_from_rest_resource(
-            api_resource, is_input=True,
-            container_repo=container_repo, process_type=MagicMock())
+        clarity_mapper = ClarityMapper()
+        analyte = clarity_mapper.analyte_create_object(
+            api_resource, is_input=True, container_repo=container_repo, process_type=MagicMock())
 
         expected_analyte = fake_analyte(container_id="cont1", artifact_id="art1", sample_ids=["sample1"],
                                         analyte_name="sample1", well_key="B:2", is_input=True,
@@ -113,7 +113,8 @@ class TestArtifact(unittest.TestCase):
         api_resource.udf = {}
         container_repo = mock_container_repo(container_id="cont1")
 
-        result_file = ResultFile.create_from_rest_resource(
+        clarity_mapper = ClarityMapper()
+        result_file = clarity_mapper.result_file_create_object(
             api_resource, is_input=False, container_repo=container_repo,
             process_type=self._create_process_type_mock(field_definitions=[]))
 
@@ -135,7 +136,8 @@ class TestArtifact(unittest.TestCase):
         api_resource.udf = udfs
         container_repo = mock_container_repo(container_id=None)
 
-        result_file = ResultFile.create_from_rest_resource(
+        clarity_mapper = ClarityMapper()
+        result_file = clarity_mapper.result_file_create_object(
             api_resource, is_input=False,
             container_repo=container_repo, process_type=self._create_process_type_mock(field_definitions=["UDF1"]))
 

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -162,7 +162,7 @@ def mock_step_repository(analyte_set):
     """
     session = MagicMock()
     session.api = MagicMock()
-    step_repo = StepRepository(session=session)
+    step_repo = StepRepository(session=session, clarity_mapper=MagicMock())
     step_repo.all_artifacts = analyte_set
     return step_repo
 

--- a/test/unit/clarity_ext/service/test_artifact_service.py
+++ b/test/unit/clarity_ext/service/test_artifact_service.py
@@ -45,7 +45,7 @@ class TestArtifactService(unittest.TestCase):
         _, outp = artifact_svc.all_artifacts()[0]
         self.assertIsNotNone(outp.udf_target_conc_ngul, "Unexpected test setup")
 
-        clarity_svc = ClarityService(MagicMock(), MagicMock())
+        clarity_svc = ClarityService(MagicMock(), MagicMock(), MagicMock())
         clarity_svc.update([outp])
         clarity_svc.step_repository.update_artifacts.assert_not_called()
 
@@ -62,6 +62,6 @@ class TestArtifactService(unittest.TestCase):
         # Update through the ClarityService, since all objects uses the same update method:
         outp.udf_target_conc_ngul += 1
 
-        clarity_svc = ClarityService(MagicMock(), MagicMock())
+        clarity_svc = ClarityService(MagicMock(), MagicMock(), MagicMock())
         clarity_svc.update([outp])
         clarity_svc.step_repository.update_artifacts.assert_called_once()

--- a/validate-unit.sh
+++ b/validate-unit.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 echo "Running unittests"
 echo "-----------------"
-nosetests -v ./test/unit --with-coverage --cover-html --cover-package=clarity_ext --cover-erase 2>&1
+
+if [ "$1" == "-v" ]; then
+    nosetests -v ./test/unit --with-coverage --cover-html --cover-package=clarity_ext --cover-erase 2>&1
+else
+    nosetests ./test/unit 2>&1
+fi
 

--- a/validate.sh
+++ b/validate.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
+if [ "$1" == "-v" ]; then
+    echo "Running all tests with coverage with a detailed report"
+    echo "-------------------------"
+    nosetests -v ./test --with-coverage --cover-html --cover-package=clarity_ext --cover-erase 2>&1
+else
+    echo "Running all tests"
+    echo "-------------------------"
+    nosetests ./test 2>&1
+fi
 
-echo "Running all tests with coverage"
-echo "-------------------------"
-nosetests -v ./test --with-coverage --cover-html --cover-package=clarity_ext --cover-erase


### PR DESCRIPTION
- Create ClarityMapper, a mapper object between api objects and domain
  objects. This will handle all the mapping in the future (ticket
  created)
- Move factory methods from some domain objects to ClarityMapper
- Support updating sample UDFs
- Fix tests
- Fix validation scripts