### PR TITLE
Add a temporary is_pooled setting

### DIFF
--- a/clarity_ext/service/dilution/service.py
+++ b/clarity_ext/service/dilution/service.py
@@ -212,7 +212,8 @@ class DilutionSession(object):
          - Source vol. should be updated on the source analyte
         """
         for target, transfers in self.group_transfers_by_target_analyte(transfer_batches).items():
-            if target.is_pool:
+            # TODO: The `is_pooled` check is a quick-fix.
+            if target.is_pool and self.dilution_settings.is_pooled:
                 regular_transfers = [t for t in transfers if not t.source_location.artifact.is_control]
                 source_vol_delta = list(set(t.source_vol_delta for t in regular_transfers
                                             if t.should_update_source_vol))
@@ -488,6 +489,9 @@ class DilutionSettings:
         self.make_pools = make_pools
         self.include_control = True
         self.fixed_sample_volume = fixed_sample_volume
+
+        # NOTE: This is part of a quick-fix (used in one particular corner case)
+        self.is_pooled = False
 
     @staticmethod
     def _parse_conc_ref(concentration_ref):


### PR DESCRIPTION
- We need a temporary check for is_pooled when fetching update infos
  for a target analyte. The code segment being guarded by this setting
  should only be executed in extensions that opt-in for it, i.e. this
  should not be the default case for all pools.
- The name of the setting is not particularly good, but the plan is that
  it's a temporary fix anyway.