### PR TITLE
Exclude controls from the source container list in xml file

### DIFF
--- a/clarity_ext/service/dilution/service.py
+++ b/clarity_ext/service/dilution/service.py
@@ -749,7 +749,8 @@ class TransferBatch(object):
     def container_mappings(self):
         ret = set()
         for transfer in self.transfers:
-            ret.add((transfer.source_slot, transfer.target_slot))
+            if not transfer.source_location.artifact.is_control:
+                ret.add((transfer.source_slot, transfer.target_slot))
         ret = list(sorted(ret, key=lambda t: t[0].index))
         return ret
 


### PR DESCRIPTION
Negative controls are taken from the trough and should not be included
in this list.