### PR TITLE
Fix bug caused by shadowed name

### DIFF
--- a/clarity_ext/service/artifact_service.py
+++ b/clarity_ext/service/artifact_service.py
@@ -155,9 +155,9 @@ class ArtifactService:
             parent_input_artifacts = list(self.parent_input_artifacts())
             self._parent_input_artifacts_by_sample_id = dict()
             for parent_input_artifact in parent_input_artifacts:
-                for sample in parent_input_artifact.samples:
-                    assert sample.id not in self._parent_input_artifacts_by_sample_id
-                    self._parent_input_artifacts_by_sample_id[sample.id] = parent_input_artifact
+                for current_sample in parent_input_artifact.samples:
+                    assert current_sample.id not in self._parent_input_artifacts_by_sample_id
+                    self._parent_input_artifacts_by_sample_id[current_sample.id] = parent_input_artifact
         return self._parent_input_artifacts_by_sample_id[sample.id]
 
     def all_output_result_files(self):


### PR DESCRIPTION
The variable name `sample` was shadowing the parameter name `sample`.
Because of this, the loop changed the sample to some other sample and
finally returned the parent input artifact for that sample.

We saw this because the final sample was phix, but this could have
broken randomly for other samples too.