### PR TITLE
1438 - Update pycharm template

### DIFF
--- a/clarity_ext/resources/templates/_base/pycharm_config.xml.j2
+++ b/clarity_ext/resources/templates/_base/pycharm_config.xml.j2
@@ -14,9 +14,10 @@
     <option name="ADD_SOURCE_ROOTS" value="false" />
     <module name="{{ module_name }}" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" runner="coverage.py" />
-    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/../clarity-ext/clarity_ext/cli.py" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/clarity-ext/clarity_ext/cli.py" />
     <option name="PARAMETERS" value="--level {{ debug_level }} extension --cache {{ use_cache }} {{ extension_module }} test" />
     <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
     <method />
   </configuration>
 </component>


### PR DESCRIPTION
The pycharm template now assumes that clarity-ext is contained within
the script project as a submodule, since that's how it's used here.