### PR TITLE
Fix transfer sort order

### DIFF
--- a/clarity_ext/service/dilution/service.py
+++ b/clarity_ext/service/dilution/service.py
@@ -568,8 +568,7 @@ class RobotSettings(object):
         assert transfer.transfer_batch is not None
         assert transfer.source_slot is not None
         assert transfer.source_slot.index is not None
-        return (transfer.source_location.artifact.is_control,
-                transfer.source_slot.index,
+        return (transfer.source_slot.index,
                 transfer.source_location.index_down_first,
                 -transfer.pipette_total_volume)
 


### PR DESCRIPTION
Control samples should be sorted as ordinary samples (robot software freak out otherwise)