### PR TITLE
Add exception handling when writing to the step log

### DIFF
--- a/clarity_ext/service/step_logger_service.py
+++ b/clarity_ext/service/step_logger_service.py
@@ -41,10 +41,14 @@ class StepLoggerService:
         msg = "{} - {}".format(time_str, msg)
         if self.step_log:
             # TODO: Get formatting from the core logging framework
-            if level:
-                self.step_log.write("{} - {}".format(logging.getLevelName(level), msg + self.NEW_LINE))
-            else:
-                self.step_log.write("{}".format(msg + self.NEW_LINE))
+            try:
+                if level:
+                    self.step_log.write("{} - {}".format(logging.getLevelName(level), msg + self.NEW_LINE))
+                else:
+                    self.step_log.write("{}".format(msg + self.NEW_LINE))
+            except ValueError:
+                # Temporary error handling for when we try to write to the step log and it has already been closed
+                pass
 
         # Forward to the core logger:
         if level:


### PR DESCRIPTION
The step log may have been uploaded already and the file closed when
writing to it. For now we solve that by ignoring thrown ValueErrors.