### PR TITLE
Split up method set_well in Container

### DIFF
--- a/clarity_ext/domain/container.py
+++ b/clarity_ext/domain/container.py
@@ -138,7 +138,7 @@ class Container(DomainObjectMixin):
         if self._append_iterator is None:
             self._append_iterator = self._traverse(order=self.append_order)
         well_pos = next(self._append_iterator)
-        self.set_well(well_pos, artifact)
+        self.set_well_update_artifact(well_pos, artifact)
 
     def to_table(self):
         """Returns the wells in a list of lists"""
@@ -212,7 +212,7 @@ class Container(DomainObjectMixin):
         ret.name = resource.name
         ret.size = size
         for artifact in api_artifacts:
-            ret.set_well(artifact.location[1], artifact)
+            ret.set_well_update_artifact(artifact.location[1], artifact)
         ret.api_resource = resource
         return ret
 
@@ -257,11 +257,15 @@ class Container(DomainObjectMixin):
                 "Well id {} is not available in this container (type={})".format(well_pos, self))
 
         self.wells[well_pos].artifact = artifact
+        return self.wells[well_pos]
+
+    def set_well_update_artifact(self, well_pos, artifact=None):
+        updated_well = self.set_well(well_pos, artifact)
         if artifact:
             artifact.container = self
 
-        artifact.well = self.wells[well_pos]
-        return self.wells[well_pos]
+        artifact.well = updated_well
+        return updated_well
 
     @property
     def occupied(self):
@@ -272,7 +276,7 @@ class Container(DomainObjectMixin):
         return self.enumerate_wells(order=self.DOWN_FIRST)
 
     def __setitem__(self, key, value):
-        self.set_well(key, artifact=value)
+        self.set_well_update_artifact(key, artifact=value)
 
     def __contains__(self, item):
         return item in self.wells

--- a/clarity_ext/service/dilution/service.py
+++ b/clarity_ext/service/dilution/service.py
@@ -645,6 +645,8 @@ class TransferBatch(object):
         self._set_transfers(transfers)
         self.name = name
         self._transfers_by_output_dict = None
+        # Target containers may be adjusted with number samples according to when batch is performed
+        self.target_containers = None
         # Set to True if the transfer batch was split
         self.split = False
 

--- a/clarity_ext/utility/testing.py
+++ b/clarity_ext/utility/testing.py
@@ -100,8 +100,8 @@ class DilutionTestDataHelper:
         name = "FROM:{}".format(pos_from)
         pair = ArtifactPair(self._create_analyte(True, name, source_type),
                             self._create_analyte(False, name, target_type))
-        source_container.set_well(pos_from, artifact=pair.input_artifact)
-        target_container.set_well(pos_to, artifact=pair.output_artifact)
+        source_container.set_well_update_artifact(pos_from, artifact=pair.input_artifact)
+        target_container.set_well_update_artifact(pos_to, artifact=pair.output_artifact)
         self.pairs.append(pair)
         return pair
 

--- a/test/unit/clarity_ext/helpers.py
+++ b/test/unit/clarity_ext/helpers.py
@@ -59,7 +59,7 @@ def fake_result_file(artifact_id=None, name=None, container_id=None, well_key=No
                      name=name, well=well)
 
     if container:
-        container.set_well(well.position, artifact=ret)
+        container.set_well_update_artifact(well.position, artifact=ret)
     return ret
 
 


### PR DESCRIPTION
For method set_well in Container, I stumbled over a case when I don't
want to update the input artifact (which was updated), only the
internal dict self.wells. I changed the name of the method, 

set_well --> wet_well_update_artifact, 

and added a new method, set_well. set_well_update_artifact calls
set_well, and then update artifact. All references to set_well are
changed to set_well_update_artifact.
