### PR TITLE
1567 Separate files for errors and warnings

### DIFF
--- a/clarity_ext/service/file_service.py
+++ b/clarity_ext/service/file_service.py
@@ -88,6 +88,7 @@ class FileService:
 
     def queue(self, downloaded_path, artifact, file_prefix):
         file_name = os.path.basename(downloaded_path)
+        self.artifactid_by_filename[file_name] = artifact.id
         if file_prefix == FileService.FILE_PREFIX_ARTIFACT_ID and not file_name.startswith(artifact.id):
             file_name = "{}_{}".format(artifact.id, file_name)
         elif file_prefix == FileService.FILE_PREFIX_NONE:
@@ -191,7 +192,6 @@ class FileService:
 
     def _upload_single(self, artifact, file_handle, instance_name, content, file_prefix):
         """Queues the file for update. Call commit to send to the server."""
-        self.artifactid_by_filename[instance_name] = artifact.id
         local_path = self.save_locally(content, instance_name)
         self.logger.info("Queuing file '{}' for upload to the server, file handle '{}'".format(local_path, file_handle))
         self.queue(local_path, artifact, file_prefix)
@@ -350,7 +350,7 @@ class LocalSharedFileProvider:
         # No match, take the first artifact with no files yet associated
         if fallback_on_first_unassigned and len(filtered_artifacts) == 0:
             for a in by_handle:
-                if len(a.files) == 0:
+                if len(a.files) == 0 and a.id not in self.file_service.artifactid_by_filename.itervalues():
                     filtered_artifacts = [a]
                     break
         elif not fallback_on_first_unassigned and len(filtered_artifacts) == 0:

--- a/clarity_ext/service/file_service.py
+++ b/clarity_ext/service/file_service.py
@@ -334,8 +334,9 @@ class LocalSharedFileProvider:
 
     def _artifact_by_name(self, file_handle, filename=None, fallback_on_first_unassigned=False):
         shared_files = self.artifact_service.shared_files()
-        by_handle = [shared_file for shared_file in shared_files
-                     if shared_file.name == file_handle]
+        by_handle = sorted([shared_file for shared_file in shared_files
+                            if shared_file.name == file_handle],
+                           key=lambda f: int(f.id.replace('92-', '')))
 
         # Search for a match from already existing files
         filtered_artifacts = list()

--- a/clarity_ext/service/step_logger_service.py
+++ b/clarity_ext/service/step_logger_service.py
@@ -10,10 +10,14 @@ class StepLoggerService:
     Provides support for logging to shared files in a step.
     """
 
-    def __init__(self, step_logger_name, file_service, raise_if_not_found=False, append=True, extension="log",
-                 write_to_stdout=True):
+    def __init__(self, file_handle, file_service, raise_if_not_found=False, append=True, extension="txt",
+                 write_to_stdout=True, filename=None):
         self.core_logger = logging.getLogger(__name__)
-        self.step_logger_name = step_logger_name
+        self.file_handle = file_handle
+        if filename is None:
+            self.filename = file_handle.replace(' ', '_')
+        else:
+            self.filename = filename
         self.file_service = file_service
         self.raise_if_not_found = raise_if_not_found
         self.append = append
@@ -28,8 +32,11 @@ class StepLoggerService:
     def step_log(self):
         try:
             mode = "ab" if self.append else "wb"
-            return self.file_service.local_shared_file(self.step_logger_name, extension=self.extension,
-                                                       mode=mode, modify_attached=True)
+            return self.file_service.local_shared_file_search_or_create(self.file_handle,
+                                                                        extension=self.extension,
+                                                                        mode=mode,
+                                                                        modify_attached=True,
+                                                                        filename=self.filename)
         except SharedFileNotFound:
             if self.raise_if_not_found:
                 raise

--- a/clarity_ext/service/step_logger_service.py
+++ b/clarity_ext/service/step_logger_service.py
@@ -81,3 +81,35 @@ class StepLoggerService:
         # This factory method is added for readability in the extensions.
         return StepLoggerService(name, self.file_service, raise_if_not_found=True, append=False)
 
+
+class AggregatedStepLoggerService:
+    """
+    Contains a list of step logger services, and have the same interface as
+    StepLoggerService.
+    Errors and warnings are written to step logs dedicated to the respective type
+    """
+    def __init__(self, default_step_logger_service, warnings_step_logger_service=None,
+                 errors_step_logger_service=None):
+        self.default_step_logger_service = default_step_logger_service
+        self.warnings_step_logger_service = warnings_step_logger_service
+        self.errors_step_logger_service = errors_step_logger_service
+
+    def error(self, msg):
+        self.default_step_logger_service.error(msg)
+        if self.errors_step_logger_service is not None:
+            self.errors_step_logger_service.error(msg)
+
+    def warning(self, msg):
+        self.default_step_logger_service.warning(msg)
+        if self.warnings_step_logger_service is not None:
+            self.warnings_step_logger_service.warning(msg)
+
+    def info(self, msg):
+        self.default_step_logger_service.info(msg)
+
+    def log(self, msg):
+        self.default_step_logger_service.log(msg)
+
+    def get(self, name):
+        # This factory method is added for readability in the extensions.
+        return StepLoggerService(name, self.default_step_logger_service.file_service, raise_if_not_found=True, append=False)

--- a/clarity_ext/service/validation_service.py
+++ b/clarity_ext/service/validation_service.py
@@ -1,15 +1,22 @@
 import logging
 from clarity_ext.domain.validation import ValidationType, UsageError
+from clarity_ext.service.step_logger_service import AggregatedStepLoggerService
 
 
 class ValidationService:
 
     def __init__(self, step_logger_service, logger=None):
         self.logger = logger or logging.getLogger(__name__)
-        self.step_logger_service = step_logger_service
+        self.step_logger_service = AggregatedStepLoggerService(step_logger_service)
         self.warning_count = 0
         self.error_count = 0
         self.messages = set()
+
+    def add_separate_warning_step_log(self, step_logger_service):
+        self.step_logger_service.warnings_step_logger_service = step_logger_service
+
+    def add_separate_error_step_log(self, step_logger_service):
+        self.step_logger_service.errors_step_logger_service = step_logger_service
 
     def handle_validation(self, results):
         """
@@ -30,13 +37,16 @@ class ValidationService:
             # Quick fix: the messages per transfers are often duplicated. Skip adding them several times to the log.
             return
         self.messages.add(msg_row)
-        self.step_logger_service.log(msg_row)
         self._log_debug("{}".format(msg_row))
 
         if result.type == ValidationType.ERROR:
+            self.step_logger_service.error(msg_row)
             self.error_count += 1
-        if result.type == ValidationType.WARNING:
+        elif result.type == ValidationType.WARNING:
+            self.step_logger_service.warning(msg_row)
             self.warning_count += 1
+        else:
+            self.step_logger_service.log(msg_row)
 
     def _log_debug(self, msg):
         if self.logger is not None:

--- a/clarity_ext/utility/testing.py
+++ b/clarity_ext/utility/testing.py
@@ -204,6 +204,7 @@ class TestExtensionContext(object):
     def add_shared_result_file(self, f):
         assert f.name is not None, "You need to supply a name"
         f.id = "92-{}".format(len(self._shared_files))
+        f.api_resource = MagicMock()
         self._shared_files.append((None, f))
 
     def add_udf_to_step(self, key, value):


### PR DESCRIPTION
Purpose:
Have separate files for warnings and errors in so that it's easier for the user to see if there are any errors/warnings. The presense of a Warnings.txt file will tell if there are warnings, which is otherwise hard to detect. 

Implementation:
Swap the step logger service instance in validaiton service to a aggregated step logger service. This class is wrapping a step logger service and has the same interface as the wrapped class, and have the option to add separate log services for warnings and errors. Also, add input for file name to the step logger service, to have step log names different than the file handle. 