### PR TITLE
Fetch error log artifact

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -126,8 +126,8 @@ class ExtensionContext(object):
         Returns a file on the current step that can be used for marking the step as having an error
         without having a visible UDF on the step.
         """
-        file_list = [file for file in self.shared_files if file.name ==
-                     self.step_log_name]
+        file_list = [file for file in self.shared_files if self.step_log_name.lower() in file.file_name.lower()]
+
         if not len(file_list) == 1:
             raise ValueError("This step is not configured with the shared file entry for {}".format(
                 self.step_log_name))
@@ -135,7 +135,7 @@ class ExtensionContext(object):
 
     @property
     def step_log_name(self):
-        return self.validation_service.step_logger_service.step_logger_name
+        return self.validation_service.step_logger_service.step_logger_name.replace(' ', '_')
 
     @property
     def shared_files(self):

--- a/clarity_ext/domain/shared_result_file.py
+++ b/clarity_ext/domain/shared_result_file.py
@@ -19,6 +19,13 @@ class SharedResultFile(Artifact):
         self._unlink_files_from_artifact(disabled, logger, session)
         self.files = list()
 
+    @property
+    def file_name(self):
+        if len(self.files) > 0:
+            return self.files[0].original_location
+        else:
+            return ''
+
     def _unlink_files_from_artifact(self, disabled, logger, session):
         for f in self.files:
             if disabled:

--- a/clarity_ext/service/step_logger_service.py
+++ b/clarity_ext/service/step_logger_service.py
@@ -91,6 +91,7 @@ class AggregatedStepLoggerService:
     def __init__(self, default_step_logger_service, warnings_step_logger_service=None,
                  errors_step_logger_service=None):
         self.default_step_logger_service = default_step_logger_service
+        self.step_logger_name = default_step_logger_service.file_handle
         self.warnings_step_logger_service = warnings_step_logger_service
         self.errors_step_logger_service = errors_step_logger_service
 


### PR DESCRIPTION
With the recently new implementation of separate files for error and
warnings, the implemention of fetch error log artifact, from context,
must be updated.

1) Add field step_logger_name to AggregatedStepLoggerService
2) Search step log artifact on basis for the file name, instead of file
handle.