### PR TITLE
1659 Improve error messages in dilution

### DIFF
--- a/clarity_ext/domain/udf.py
+++ b/clarity_ext/domain/udf.py
@@ -148,6 +148,9 @@ class UdfMapping(object):
     def __setitem__(self, key, value):
         self.unwrap(key).value = value
 
+    def udf_name_in_lims_ui(self, py_udf):
+        return self.raw_map[py_udf][0].key
+
     def unwrap(self, key):
         """
         First tries to fetch by the original key, raises an exception if there

--- a/clarity_ext/service/dilution/service.py
+++ b/clarity_ext/service/dilution/service.py
@@ -623,13 +623,12 @@ class TransferValidationException(ValidationException):
         self.transfer = transfer
 
     def __repr__(self):
-        return "{}: {} Transfer for {} ({}@{} => {}@{}) - {}".format(
+        return "{}: {}, {} ({}@{} => {}@{})".format(
             self._repr_type(),
-            self.transfer.transfer_batch.name if self.transfer.transfer_batch else "",
+            self.msg,
             self.transfer.source_location.artifact.name,
             self.transfer.source_location.position, self.transfer.source_location.container.name,
-            self.transfer.target_location.position, self.transfer.target_location.container.name,
-            self.msg)
+            self.transfer.target_location.position, self.transfer.target_location.container.name)
 
 
 class TransferBatch(object):


### PR DESCRIPTION
Peel away redundant information. Use udf name as shown in the lims-ui.

Error message before:
Error:  Transfer for in-FROM:A:1 (A:1@source1 => A:1@target1) - You need to provide the following measurements 'udf_current_sample_volume_ul' for '<SingleTransfer A1: [in-FROM:A:1](100,None=>[None]) =(0,0)=> A1: [out-FROM:A:1](None,None) primary / (None, None, None)>'

Error message after:
Error: You need to provide the following input 'Current sample volume (ul)', in-FROM:A:1 (A:1@source1 => A:1@target1)
