### PR TITLE
Add method to check file extension

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -180,7 +180,7 @@ class ExtensionContext(object):
         """
         return utils.single(self.artifact_service.all_input_containers())
 
-    def local_shared_file(self, name, mode="r", is_xml=False, is_csv=False, file_name_contains=None):
+    def local_shared_file(self, clarity_file_handle, mode="r", is_xml=False, is_csv=False, file_name_contains=None):
         """
         Downloads the file from the current step. The returned file is generally a regular
         file-like object, but can be casted to an xml object or csv by passing in is_xml or is_csv.
@@ -189,12 +189,21 @@ class ExtensionContext(object):
         NOTE: It would make sense to use constants instead of is_xml and is_csv, but since this
         is designed to be used by non-developers, this might be more readable.
         """
+        def check_file_extension(extension):
+            self.file_service.local_shared_file_provider.check_file_extension(
+                clarity_file_handle,
+                required_extension=extension,
+                filename_contains=file_name_contains
+            )
+
         if is_xml and is_csv:
             raise ValueError("More than one file type specifiers")
-        f = self.file_service.local_shared_file(name, mode=mode, file_name_contains=file_name_contains)
+        f = self.file_service.local_shared_file(clarity_file_handle, mode=mode, file_name_contains=file_name_contains)
         if is_xml:
+            check_file_extension('.xml')
             return self.file_service.parse_xml(f)
         elif is_csv:
+            check_file_extension('.csv')
             return self.file_service.parse_csv(f)
         else:
             return f

--- a/clarity_ext/service/file_service.py
+++ b/clarity_ext/service/file_service.py
@@ -266,6 +266,22 @@ class LocalSharedFileProvider:
         return self._local_shared_file(artifact, filename, mode=mode, extension=extension,
                                        modify_attached=modify_attached)
 
+    def check_file_extension(self, clarity_file_handle, required_extension=None, filename_contains=None):
+        """
+
+        :param clarity_file_handle: Type of file as written in the clarity lims ui
+        :param required_extension: the dot should be included, e.g. '.csv'
+        :param filename_contains: In case there are more than one file under a given clarity file handle
+        :return: void
+        """
+        artifact = self._artifact_by_name(clarity_file_handle, filename=filename_contains)
+        file_name = os.path.basename(artifact.file_name)
+        _, actual_extension = os.path.splitext(file_name)
+        if not required_extension == actual_extension:
+            raise SharedFileNotFound('This file has the wrong extension: {}. Expected: {}, found: {}'.format(
+                file_name, required_extension, actual_extension
+            ))
+
     def _local_shared_file(self, artifact, filename, mode='r', extension="",
                            modify_attached=False):
         """


### PR DESCRIPTION
Purpose:
User may easily by mistake upload a .xlsx file when either .csv or xml is required. Show a clear error message for this. 

In context.local_shared_file(), if the searched file is csv or xml,
check that the found artifact has a file with the right extension, i.e.
.csv or .xml. If not, cast exception with proper message. 