### PR TITLE
Fix sort strategy on output positions

### DIFF
--- a/clarity_ext/service/dilution/service.py
+++ b/clarity_ext/service/dilution/service.py
@@ -513,7 +513,8 @@ class SortStrategy:
                 transfer.target_slot.index,
                 transfer.target_location.index_down_first)
 
-    def output_position_sort_key(self, transfer):
+    @staticmethod
+    def output_position_sort_key(transfer):
         """
         Sort the transfers based on:
             - target position (container.index)


### PR DESCRIPTION
Like input_position_sort_key(), it should be a static method with only
one input argument.