### PR TITLE
1737, fix phix names in pooling

### DIFF
--- a/clarity_ext/domain/artifact.py
+++ b/clarity_ext/domain/artifact.py
@@ -18,11 +18,20 @@ class Artifact(DomainObjectWithUdfMixin):
         super(Artifact, self).__init__(api_resource=api_resource, id=artifact_id, udf_map=udf_map)
         self.is_input = None  # Set to true if this is an input artifact
         self.generation_type = None  # Set to PER_INPUT or PER_ALL_INPUTS if applicable
-        self.name = name
+        self._name = name
         self.view_name = name
 
         # NOTE: This is currently only used in tests, so you can't trust that it has been set
         self.pairings = list()
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+        self.view_name = value
 
     def pair_as_output(self, input_artifact):
         return self.pair_together(input_artifact, self)


### PR DESCRIPTION
Bug:
Instead of phiX name, it's shown 'none' in the dilution files for pooling. 

Reason for bug:
There is a distinction between name and view_name in artifiact,
* name, updates the db via API, so that name is updated in later steps
* view_name, this is the field that is actually behind what is shown in dilution files. There is a separate field for this in order to show temporarily more verbose names in a certain step. 

Bugfix:
Make artifact.name a property. Each time name is set, also updates view_name. 