### PR TITLE
Add function to fetch all analyte pairs for specific process

### DIFF
--- a/clarity_ext/service/artifact_service.py
+++ b/clarity_ext/service/artifact_service.py
@@ -167,3 +167,12 @@ class ArtifactService:
         """
         return [output for _, output in self.all_artifacts()
                 if output.generation_type == output.PER_INPUT]
+
+    def get_all_analyte_pairs_from_process(self, process):
+        """
+        Returns all analyte_pairs from a specific process
+        """
+        process_step_repo = StepRepository(ClaritySession.create(process.id),
+                                          self.step_repository.clarity_mapper)
+        parent_artifact_service = ArtifactService(process_step_repo)
+        return parent_artifact_service.all_analyte_pairs()


### PR DESCRIPTION
This is part of a fix for https://snpseq.atlassian.net/browse/LIMS-1747. This function will be used in a clarity-ext-script, which I'm pushing to clarity-snpseq. 