### PR TITLE
 1893 dilute to tubes

### DIFF
--- a/clarity_ext/domain/container.py
+++ b/clarity_ext/domain/container.py
@@ -104,6 +104,7 @@ class Container(DomainObjectWithUdfMixin):
     RIGHT_FIRST = 2
 
     CONTAINER_TYPE_96_WELLS_PLATE = "96 well plate"
+    CONTAINER_TYPE_TUBE = "Tube"
 
     def __init__(self, mapping=None, size=None, container_type=None,
                  container_id=None, name=None, is_source=None, append_order=DOWN_FIRST, sort_weight=0, udf_map=None):
@@ -180,6 +181,8 @@ class Container(DomainObjectWithUdfMixin):
     def size_from_container_type(self, container_type):
         if container_type == self.CONTAINER_TYPE_96_WELLS_PLATE:
             return PlateSize(height=8, width=12)
+        if container_type == self.CONTAINER_TYPE_TUBE:
+            return PlateSize(height=1, width=1)
         else:
             raise ValueError("Can't initialize container size from plate name {}".format(container_type))
 

--- a/clarity_ext/service/dilution/service.py
+++ b/clarity_ext/service/dilution/service.py
@@ -147,7 +147,8 @@ class DilutionSession(object):
         transfer_routes = dict()
 
         # Evaluate the transfers, i.e. execute all handlers. This does not group them into transfer batches yet
-        for transfer in transfers:
+        sorted_transfers = sorted(transfers, key=SortStrategy.input_position_pre_batching)
+        for transfer in sorted_transfers:
             route = self.evaluate_transfer_route(transfer, transfer_handlers)
             transfer_routes[transfer] = route
 
@@ -517,6 +518,17 @@ class SortStrategy:
                 -transfer.pipette_total_volume,
                 transfer.target_slot.index,
                 transfer.target_location.index_down_first)
+
+    @staticmethod
+    def input_position_pre_batching(transfer):
+        """
+        Sort transfers when plate placement on robot deck not yet is decided:
+        Sort on:
+            - source plate name
+            - source well index, down first
+        """
+        return (SortStrategy.container_sort_key(transfer.source_location.container),
+                transfer.source_location.index_down_first)
 
     @staticmethod
     def output_position_sort_key(transfer):

--- a/clarity_ext/service/dilution/service.py
+++ b/clarity_ext/service/dilution/service.py
@@ -584,9 +584,11 @@ class TubeRackPositioner:
     Holds a state on how many tube racks is needed, and
     a mapping between tubes and positions in tube racks
     """
+    TUBE_RACK_START_ID = 1211111111
+
     def __init__(self, plate_size):
         self.tube_racks = list()
-        self.tube_rack_id_counter = 1
+        self.tube_rack_id_counter = 0
         self.tube_counter = 1
         self.size = plate_size
         self.number_of_wells = self.size.height * self.size.width
@@ -622,11 +624,13 @@ class TubeRackPositioner:
         return '{}'.format(container_position)
 
     def _create_new_tube_rack(self):
-        id = '{}{}'.format('tuberack', self.tube_rack_id_counter)
+        id = self.TUBE_RACK_START_ID + self.tube_rack_id_counter
+        id = str(id)
+        name = 'Tuberack{}'.format(self.tube_rack_id_counter + 1)
         self.tube_rack_id_counter += 1
         tube_rack = Container(size=PlateSize(height=4, width=6),
                               container_type=Container.CONTAINER_TYPE_96_WELLS_PLATE,
-                              container_id=id, name=id, is_source=False)
+                              container_id=id, name=name, is_source=False)
         self.tube_racks.append(tube_rack)
 
 


### PR DESCRIPTION
Prepare clarity-ext to be able for dilution to tubes.

Implementation:
Add class TubeRackPositioner. Temporarily create  tube racks and place artifacts in it, in the order of the  transfers list. Therefore, sort transfers prior to placing tubes to tube racks. Also, update container with type TUBE. 

Refactorings:
method container_sort_key is moved from clarity-snpseq to here. 