### PR TITLE
Ext 1892 loop bug

### DIFF
--- a/clarity_ext/service/dilution/service.py
+++ b/clarity_ext/service/dilution/service.py
@@ -4,7 +4,6 @@ import logging
 import re
 from itertools import groupby
 from itertools import chain
-from itertools import izip_longest
 import collections
 from collections import namedtuple
 from clarity_ext.service.file_service import Csv
@@ -97,12 +96,17 @@ class DilutionSession(object):
             batch_handlers.append(batch_handler_type(self, dilution_settings, robot_settings, virtual_batch))
         return transfer_handlers, batch_handlers
 
-    def get_temporary_container(self, target_container, prefix):
-        """Returns the temporary container that should be used rather than the original one, when splitting transfers"""
+    def get_temporary_container(self, target_container, prefix, start_id, container_template=None):
+        """Returns the temporary container that should be used
+        rather than the original one, when splitting transfers"""
         if target_container.id not in self.map_temporary_container_by_original:
-            temp_container = Container.create_from_container(target_container)
-            temp_container.id = "{}{}".format(prefix, len(self.map_temporary_container_by_original) + 1)
-            temp_container.name = temp_container.id
+            if container_template is None:
+                container_template = target_container
+            temp_container = Container.create_from_container(container_template)
+            id = int(start_id) + len(self.map_temporary_container_by_original)
+            temp_container.id = str(id)
+            name = '{}{}'.format(prefix, len(self.map_temporary_container_by_original) + 1)
+            temp_container.name = name
             temp_container.is_temporary = True
             self.map_temporary_container_by_original[target_container.id] = temp_container
         return self.map_temporary_container_by_original[target_container.id]


### PR DESCRIPTION
Fix bug with symptoms:
User make a dilution with a lot of samples, that requires more than one intermediate plate.

Implementation:
Update method get_temporary_container(), so that it provides a new temp plate for each target plate containing looped samples. Previously there was only one temp plate. 

Refactorings:
DilutionSession.get_temporary_container() is moved to separate class (maintaining a state). get_temporarily_container() also have two new input arguments, start_id and container_template. Container template is used when diluting to tube racks, in which case the intermediate plate should still be a 96 well plate (not dimensions of the tube rack).
