### PR TITLE
Ext 1925 pool with input tubes

### DIFF
--- a/clarity_ext/domain/container.py
+++ b/clarity_ext/domain/container.py
@@ -105,6 +105,7 @@ class Container(DomainObjectWithUdfMixin):
 
     CONTAINER_TYPE_96_WELLS_PLATE = "96 well plate"
     CONTAINER_TYPE_TUBE = "Tube"
+    CONTAINER_TYPE_TUBERACK = "Tuberack"
 
     def __init__(self, mapping=None, size=None, container_type=None,
                  container_id=None, name=None, is_source=None, append_order=DOWN_FIRST, sort_weight=0, udf_map=None):

--- a/clarity_ext/service/dilution/service.py
+++ b/clarity_ext/service/dilution/service.py
@@ -607,11 +607,12 @@ class TubeRackPositioner:
     """
     TUBE_RACK_START_ID = 1211111111
 
-    def __init__(self, plate_size):
+    def __init__(self, name_prefix, plate_size):
         self.tube_racks = list()
         self.tube_rack_id_counter = 0
         self.tube_counter = 1
         self.size = plate_size
+        self.name_prefix = name_prefix
         self.number_of_wells = self.size.height * self.size.width
         self.current_well_pos = None
         self.current_tube_ind = -1
@@ -669,7 +670,7 @@ class TubeRackPositioner:
     def _create_new_tube_rack(self):
         id = self.TUBE_RACK_START_ID + self.tube_rack_id_counter
         id = str(id)
-        name = 'Tuberack{}'.format(self.tube_rack_id_counter + 1)
+        name = '{}{}'.format(self.name_prefix, self.tube_rack_id_counter + 1)
         self.tube_rack_id_counter += 1
         tube_rack = Container(size=PlateSize(height=4, width=6),
                               container_type=Container.CONTAINER_TYPE_96_WELLS_PLATE,

--- a/clarity_ext/service/dilution/service.py
+++ b/clarity_ext/service/dilution/service.py
@@ -673,7 +673,7 @@ class TubeRackPositioner:
         name = '{}{}'.format(self.name_prefix, self.tube_rack_id_counter + 1)
         self.tube_rack_id_counter += 1
         tube_rack = Container(size=PlateSize(height=4, width=6),
-                              container_type=Container.CONTAINER_TYPE_96_WELLS_PLATE,
+                              container_type=Container.CONTAINER_TYPE_TUBERACK,
                               container_id=id, name=name, is_source=False)
         self.tube_racks.append(tube_rack)
 


### PR DESCRIPTION
Purpose:
1) Add tuberack as a new container type. This is used in clarity-snpseq to check if tuberack should be shown in metadatafile.
2) Configurable name prefix for tuberacks, either destination tuberack, or source tuberack. 