### PR TITLE
Ext 1970 remove duplication

### DIFF
--- a/clarity_ext/domain/aliquot.py
+++ b/clarity_ext/domain/aliquot.py
@@ -11,10 +11,10 @@ class Aliquot(Artifact):
     """
 
     def __init__(self, api_resource, is_input, id=None, samples=None, name=None, well=None, udf_map=None):
-        super(Aliquot, self).__init__(api_resource=api_resource, artifact_id=id, name=name, udf_map=udf_map)
+        super(Aliquot, self).__init__(api_resource=api_resource, artifact_id=id, name=name, udf_map=udf_map,
+                                      is_input=is_input)
         self.samples = samples
         self.well = well
-        self.is_input = is_input
         if well:
             self.container = well.container
             well.artifact = self

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -1,4 +1,5 @@
 from clarity_ext.domain.aliquot import Aliquot, Sample
+from clarity_ext.domain.artifact import Artifact
 from clarity_ext import utils
 from clarity_ext.domain.udf import UdfMapping
 
@@ -22,6 +23,7 @@ class Analyte(Aliquot):
         self.is_control = is_control
         self.is_output_from_previous = is_from_original
         self.reagent_labels = None
+        self.output_type = Artifact.OUTPUT_TYPE_ANALYTE
         if api_resource is not None:
             self.reagent_labels = api_resource.reagent_labels
 

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -23,7 +23,6 @@ class Analyte(Aliquot):
         self.is_control = is_control
         self.is_output_from_previous = is_from_original
         self.reagent_labels = None
-        self.output_type = Artifact.OUTPUT_TYPE_ANALYTE
         if api_resource is not None:
             self.reagent_labels = api_resource.reagent_labels
 
@@ -32,6 +31,9 @@ class Analyte(Aliquot):
         if self.is_input is not None:
             typename = ("Input" if self.is_input else "Output") + typename
         return "{}<{} ({})>".format(typename, self.name, self.id)
+
+    def _set_output_type(self):
+        self.output_type = Artifact.OUTPUT_TYPE_ANALYTE
 
     def get_reagent_label(self):
         return utils.single(self.reagent_labels)

--- a/clarity_ext/domain/artifact.py
+++ b/clarity_ext/domain/artifact.py
@@ -14,15 +14,21 @@ class Artifact(DomainObjectWithUdfMixin):
     OUTPUT_TYPE_ANALYTE = 2
     OUTPUT_TYPE_SHARED_RESULT_FILE = 3
 
-    def __init__(self, api_resource=None, artifact_id=None, name=None, udf_map=None):
+    def __init__(self, api_resource=None, artifact_id=None, name=None, udf_map=None, is_input=None):
         super(Artifact, self).__init__(api_resource=api_resource, id=artifact_id, udf_map=udf_map)
-        self.is_input = None  # Set to true if this is an input artifact
+        self.is_input = is_input
         self.generation_type = None  # Set to PER_INPUT or PER_ALL_INPUTS if applicable
         self._name = name
         self.view_name = name
 
         # NOTE: This is currently only used in tests, so you can't trust that it has been set
         self.pairings = list()
+        self.output_type = None
+        if not is_input:
+            self._set_output_type()
+
+    def _set_output_type(self):
+        raise NotImplementedError('Output type {} is not implemented'.format(self.__class__.__name__))
 
     @property
     def name(self):

--- a/clarity_ext/domain/result_file.py
+++ b/clarity_ext/domain/result_file.py
@@ -21,6 +21,8 @@ class ResultFile(Aliquot):
         super(self.__class__, self).__init__(api_resource, is_input=is_input, id=id,
                 samples=samples, name=name, well=well, udf_map=udf_map)
         self.is_control = False
+
+    def _set_output_type(self):
         self.output_type = Artifact.OUTPUT_TYPE_RESULT_FILE
 
     @property

--- a/clarity_ext/domain/result_file.py
+++ b/clarity_ext/domain/result_file.py
@@ -1,4 +1,5 @@
 from clarity_ext.domain.aliquot import Aliquot, Sample
+from clarity_ext.domain.artifact import Artifact
 from clarity_ext import utils
 from clarity_ext.domain.udf import UdfMapping
 
@@ -20,6 +21,7 @@ class ResultFile(Aliquot):
         super(self.__class__, self).__init__(api_resource, is_input=is_input, id=id,
                 samples=samples, name=name, well=well, udf_map=udf_map)
         self.is_control = False
+        self.output_type = Artifact.OUTPUT_TYPE_RESULT_FILE
 
     @property
     def sample(self):

--- a/clarity_ext/domain/shared_result_file.py
+++ b/clarity_ext/domain/shared_result_file.py
@@ -14,6 +14,7 @@ class SharedResultFile(Artifact):
         # TODO: These files are currently represented with api resources, not internal
         # domain objects
         self.files = files or list()
+        self.output_type = Artifact.OUTPUT_TYPE_SHARED_RESULT_FILE
 
     def remove_files(self, disabled, logger, session):
         self._unlink_files_from_artifact(disabled, logger, session)

--- a/clarity_ext/domain/shared_result_file.py
+++ b/clarity_ext/domain/shared_result_file.py
@@ -14,6 +14,8 @@ class SharedResultFile(Artifact):
         # TODO: These files are currently represented with api resources, not internal
         # domain objects
         self.files = files or list()
+
+    def _set_output_type(self):
         self.output_type = Artifact.OUTPUT_TYPE_SHARED_RESULT_FILE
 
     def remove_files(self, disabled, logger, session):

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -100,16 +100,6 @@ class StepRepository(object):
             raise NotImplementedError(
                 "Generation type {} is not implemented".format(output_gen_type))
 
-        if isinstance(output, ResultFile):
-            output.output_type = Artifact.OUTPUT_TYPE_RESULT_FILE
-        elif isinstance(output, Analyte):
-            output.output_type = Artifact.OUTPUT_TYPE_ANALYTE
-        elif isinstance(output, SharedResultFile):
-            output.output_type = Artifact.OUTPUT_TYPE_SHARED_RESULT_FILE
-        else:
-            raise NotImplementedError(
-                "Output type {} is not implemented".format(output.__class__.__name__))
-
         # Add a reference to the other object for convenience:
         input.output = output
         output.input = input

--- a/clarity_ext/utility/testing_parse_scripts/builders.py
+++ b/clarity_ext/utility/testing_parse_scripts/builders.py
@@ -1,0 +1,122 @@
+from mock import MagicMock
+from StringIO import StringIO
+from io import BytesIO
+from clarity_ext.service.file_service import Csv
+from clarity_ext.service.file_service import FileService
+from clarity_ext.service.process_service import ProcessService
+from clarity_ext.context import ExtensionContext
+from clarity_ext.service.artifact_service import ArtifactService
+from clarity_ext.domain.process import Process
+from clarity_ext.domain.user import User
+from clarity_ext.domain.udf import UdfMapping
+from clarity_ext.utility.testing_parse_scripts.fake_artifact_factory import FakeArtifactFactory
+
+
+class ContextBuilder:
+    """
+    Add entities to repositories held by context
+    E.g. shared files, artifacts, analytes.
+    """
+    def __init__(self):
+        self.step_repo = FakeStepRepo()
+        self.logger = FakeLogger()
+        self.context = None
+        self._create()
+
+    def with_analyte_pair(self, input, output):
+        self.step_repo.add_analyte_pair(input, output)
+
+    def with_mocked_local_shared_file(self, filename, contents):
+        monkey = LocalSharedFilePatcher()
+        monkey.cache[filename] = contents
+        self.context.local_shared_file = monkey.local_shared_file
+
+    def _create(self):
+        session = MagicMock()
+        file_repository = MagicMock()
+        artifact_service = ArtifactService(self.step_repo)
+        os_service = MagicMock()
+        current_user = None
+        file_service = FileService(
+            artifact_service, file_repository, False,
+            os_service, uploaded_to_stdout=False, disable_commits=True)
+        validation_service = MagicMock()
+        dilution_service = MagicMock()
+        process_service = ProcessService()
+        clarity_service = None
+        self.context = ExtensionContext(session, artifact_service, file_service, current_user,
+                                self.logger, self.step_repo, clarity_service,
+                                dilution_service, process_service, validation_service,
+                                test_mode=False, disable_commits=True)
+
+
+class PairBuilder(object):
+    def __init__(self):
+        self.artifact_repo = FakeArtifactFactory()
+        self.output_udf_dict = dict()
+        self.target_id = None
+        self.target_type = None
+        self.pair = None
+
+    def create(self):
+        pair = self.artifact_repo.create_pair(
+            pos_from=None, pos_to=None, source_id=None, target_id=self.target_id,
+            target_type=self.target_type)
+        pair.output_artifact.udf_map = UdfMapping(self.output_udf_dict)
+        self.pair = pair
+
+    def with_target_id(self, target_id):
+        self.target_id = target_id
+
+    def with_output_udf(self, lims_udf_name, value):
+        self.output_udf_dict[lims_udf_name] = value
+
+    def with_target_type(self, type):
+        self.target_type = type
+
+
+class FakeStepRepo:
+    def __init__(self):
+        self._shared_files = list()
+        self._analytes = list()
+        self.user = User("Integration", "Tester", "no-reply@medsci.uu.se", "IT")
+
+    def all_artifacts(self):
+        return self._shared_files + self._analytes
+
+    def add_analyte_pair(self, input, output):
+        self._analytes.append((input, output))
+
+    def get_process(self):
+        return Process(None, "24-1234", self.user, dict(), "http://not-avail")
+
+
+class LocalSharedFilePatcher:
+    """
+    Replace methods in Context
+    """
+    def __init__(self):
+        self.cache = dict()
+        os_service = MagicMock()
+        self.file_service = FileService(None, None, False, os_service)
+
+    def local_shared_file(self, name, mode="r", is_xml=False, is_csv=False, file_name_contains=None):
+        if is_csv:
+            content = self.cache[name]
+            stream = StringIO(content)
+            return Csv(stream)
+        else:
+            content = self.cache[name]
+            bs = BytesIO(b'{}'.format(content.encode('utf-8')))
+            return self.file_service.parse_xml(bs)
+
+
+class FakeLogger:
+    def __init__(self):
+        self.warnings = list()
+
+    def warning(self, text):
+        self.warnings.append(text)
+
+    def log(self, text):
+        pass

--- a/clarity_ext/utility/testing_parse_scripts/builders.py
+++ b/clarity_ext/utility/testing_parse_scripts/builders.py
@@ -1,8 +1,10 @@
 from mock import MagicMock
 from StringIO import StringIO
 from io import BytesIO
+from mock import create_autospec
 from clarity_ext.service.file_service import Csv
 from clarity_ext.service.file_service import FileService
+from clarity_ext.service.file_service import OSService
 from clarity_ext.service.process_service import ProcessService
 from clarity_ext.context import ExtensionContext
 from clarity_ext.service.artifact_service import ArtifactService
@@ -32,18 +34,18 @@ class ContextBuilder:
         self.context.local_shared_file = monkey.local_shared_file
 
     def _create(self):
-        session = MagicMock()
-        file_repository = MagicMock()
-        artifact_service = ArtifactService(self.step_repo)
-        os_service = MagicMock()
+        session = None
+        clarity_service = None
+        file_repository = None
         current_user = None
+        validation_service = None
+        dilution_service = None
+        os_service = OSService()
+        process_service = ProcessService()
+        artifact_service = ArtifactService(self.step_repo)
         file_service = FileService(
             artifact_service, file_repository, False,
             os_service, uploaded_to_stdout=False, disable_commits=True)
-        validation_service = MagicMock()
-        dilution_service = MagicMock()
-        process_service = ProcessService()
-        clarity_service = None
         self.context = ExtensionContext(session, artifact_service, file_service, current_user,
                                 self.logger, self.step_repo, clarity_service,
                                 dilution_service, process_service, validation_service,

--- a/clarity_ext/utility/testing_parse_scripts/fake_artifact_factory.py
+++ b/clarity_ext/utility/testing_parse_scripts/fake_artifact_factory.py
@@ -1,0 +1,43 @@
+from clarity_ext.domain import *
+from clarity_ext.service.dilution.service import *
+
+
+class FakeArtifactFactory:
+    """
+    Create artifact pairs and place them in containers
+    Containers are stored and re-used between calls to create_pair()
+    """
+    def __init__(self, create_well_order=Container.DOWN_FIRST,
+                 source_container_type=Container.CONTAINER_TYPE_96_WELLS_PLATE,
+                 target_container_type=Container.CONTAINER_TYPE_96_WELLS_PLATE):
+
+        self.default_source_container = self._create_container('source', True, source_container_type)
+        self.default_target_container = self._create_container('target', False, target_container_type)
+        self.well_enumerator = self.default_source_container.enumerate_wells(create_well_order)
+
+    def _create_container(self, container_id, is_source, container_type):
+        return Container(
+            container_type=container_type, container_id=container_id,
+            name=container_id, is_source=is_source)
+
+    def _create_artifact(self, is_input, name, artifact_type=None, id=None):
+        return artifact_type(
+            is_input=is_input, id=id, name=name,samples=None, api_resource=None)
+
+    def create_pair(self, pos_from=None, pos_to=None, source_type=Analyte,
+                    target_type=Analyte, source_id=None, target_id=None):
+
+        if pos_from is None:
+            well = self.well_enumerator.next()
+            pos_from = well.position
+        if pos_to is None:
+            pos_to = pos_from
+
+        source_name = 'in-FROM:{}-{}'.format('source', pos_from)
+        target_name = "out-FROM:{}-{}".format('target', pos_from)
+
+        pair = ArtifactPair(self._create_artifact(True, source_name, source_type, id=source_id),
+                            self._create_artifact(False, target_name, target_type, id=target_id))
+        self.default_source_container.set_well_update_artifact(pos_from, artifact=pair.input_artifact)
+        self.default_target_container.set_well_update_artifact(pos_to, artifact=pair.output_artifact)
+        return pair

--- a/test/unit/clarity_ext/domain/test_artifact.py
+++ b/test/unit/clarity_ext/domain/test_artifact.py
@@ -15,16 +15,15 @@ from clarity_ext.mappers.clarity_mapper import ClarityMapper
 class TestArtifact(unittest.TestCase):
     def test_two_identical_artifacts_equal(self):
         """A copy of an artifact should be equal to another"""
-        artifacts = [Artifact(), Artifact()]
+        artifacts = [ResultFile(api_resource=None, is_input=False),
+                     ResultFile(api_resource=None, is_input=False)]
         for artifact in artifacts:
-            artifact.generation_type = Artifact.OUTPUT_TYPE_RESULT_FILE
-            artifact.is_input = False
             artifact.any_patch = "13370"
 
         self.assertEqual(artifacts[0], artifacts[1])
 
     def test_artifact_should_not_equal_non_artifact(self):
-        artifact = Artifact()
+        artifact = ResultFile(api_resource=None, is_input=False)
         self.assertNotEqual(artifact, "string")
 
     def test_equality_including_mutual_references(self):

--- a/test/unit/clarity_ext/service/test_file_service.py
+++ b/test/unit/clarity_ext/service/test_file_service.py
@@ -1,6 +1,6 @@
 import unittest
 from mock import MagicMock
-from clarity_ext.domain.artifact import Artifact
+from clarity_ext.domain.analyte import Analyte
 from clarity_ext.service.file_service import FileService
 
 
@@ -23,7 +23,7 @@ class TestUploadFileService(unittest.TestCase):
 
 
 def fake_artifact(artifact_id, name):
-    artifact = Artifact()
+    artifact = Analyte(api_resource=None, is_input=False)
     artifact.name = name
     artifact.id = artifact_id
     return artifact


### PR DESCRIPTION
Purpose:
Create a slim test framework for parsing scripts.

Implementation:
* Instantiate ExtensionContext without connecting to network, only using fake entities
* Configure ExtensionContext with a number of fake artifact pairs (input & output)
* Configure each fake artifact pair with a number of udfs required by the script