### PR TITLE
1999, fix navigation reference bug in template extension

### DIFF
--- a/clarity_ext/extensions.py
+++ b/clarity_ext/extensions.py
@@ -707,6 +707,19 @@ class TemplateExtension(DriverFileExtension):
         if len(candidates) > 1:
             raise ValueError("More than one template file found: ", ",".join(candidates))
         self.default_template_name = candidates[0] if len(candidates) == 1 else None
+        self.output_by_input_id = None
+
+    def build_artifact_dict(self):
+        output_by_input_id = dict()
+        pairs = self.context.artifact_service.all_aliquot_pairs()
+        for pair in pairs:
+            output_by_input_id[pair.input_artifact.id] = pair.output_artifact
+        self.output_by_input_id = output_by_input_id
+
+    def get_output(self, input_id):
+        if self.output_by_input_id is None:
+            self.build_artifact_dict()
+        return self.output_by_input_id[input_id]
 
     @property
     def template_path(self):

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -101,6 +101,11 @@ class StepRepository(object):
                 "Generation type {} is not implemented".format(output_gen_type))
 
         # Add a reference to the other object for convenience:
+        # TODO: There are generally several input pairs containing the same input
+        # artifact within the same step, where output is either shared result file, or
+        # analyte/resultfile. As a consequence, there are several instances of the same
+        # input artifact, with different values of .output. When populating containers, there
+        # is no check as of which one of these input artifacts are used!
         input.output = output
         output.input = input
 


### PR DESCRIPTION
Purpose:
Fix bug in a template script, where the input.output navigation variable refers to a shared result file instead of a sample (resultfile/analyte). 

Implementation:
In TemplateExtension base script, build a dictionary for input-> output variables, referring only to samples (shared result files excluded). Use this dictionary instead of the original navigation variable input.output.