### PR TITLE
Add convenience methods for logging

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -9,6 +9,8 @@ from clarity_ext.repository import StepRepository
 from clarity_ext import utils
 from clarity_ext.service.file_service import OSService
 from clarity_ext.mappers.clarity_mapper import ClarityMapper
+from clarity_ext.domain.validation import ValidationException
+from clarity_ext.domain.validation import ValidationType
 
 
 class ExtensionContext(object):
@@ -60,6 +62,7 @@ class ExtensionContext(object):
         self.validation_service = validation_service
         self.disable_commits = disable_commits
         self._calls_to_commit = 0
+        self.validation_results = list()
 
     @staticmethod
     def create(step_id, test_mode=False, uploaded_to_stdout=False, disable_commits=False):
@@ -191,6 +194,19 @@ class ExtensionContext(object):
                                             filename='Errors', raise_if_not_found=True)
         self.validation_service.add_separate_error_step_log(errors_step_log)
 
+    def stage_error(self, msg):
+        msg = '{} {}'.format(ValidationType.ERROR, msg)
+        e = ValidationException(msg, ValidationType.ERROR)
+        self.validation_results.append(e)
+
+    def stage_warning(self, msg):
+        msg = '{} {}'.format(ValidationType.WARNING, msg)
+        e = ValidationException(msg, ValidationType.WARNING)
+        self.validation_results.append(e)
+
+    def handle_validation(self, msg=None):
+        self.validation_service.handle_validation(
+            self.validation_results, tailored_error_message=msg)
 
     def local_shared_file(self, clarity_file_handle, mode="r", is_xml=False, is_csv=False, file_name_contains=None):
         """

--- a/clarity_ext/service/validation_service.py
+++ b/clarity_ext/service/validation_service.py
@@ -18,7 +18,7 @@ class ValidationService:
     def add_separate_error_step_log(self, step_logger_service):
         self.step_logger_service.errors_step_logger_service = step_logger_service
 
-    def handle_validation(self, results):
+    def handle_validation(self, results, tailored_error_message=None):
         """
         Pushes validation results to the logging framework
         """
@@ -29,7 +29,9 @@ class ValidationService:
                 self.handle_single_validation(result)
         # If any of the validation results were errors, raise an exception:
         if any(result for result in results if result.type == ValidationType.ERROR):
-            raise UsageError("Errors during validation. See the step log for further details.", results)
+            msg = tailored_error_message if tailored_error_message is not None \
+                else "Errors during validation. See the step log for further details."
+            raise UsageError(msg, results)
 
     def handle_single_validation(self, result):
         msg_row = "{}".format(result)

--- a/clarity_ext/utility/testing_parse_scripts/builders.py
+++ b/clarity_ext/utility/testing_parse_scripts/builders.py
@@ -6,11 +6,14 @@ from clarity_ext.service.file_service import Csv
 from clarity_ext.service.file_service import FileService
 from clarity_ext.service.file_service import OSService
 from clarity_ext.service.process_service import ProcessService
+from clarity_ext.service.validation_service import ValidationService
+from clarity_ext.service.step_logger_service import StepLoggerService
 from clarity_ext.context import ExtensionContext
 from clarity_ext.service.artifact_service import ArtifactService
 from clarity_ext.domain.process import Process
 from clarity_ext.domain.user import User
 from clarity_ext.domain.udf import UdfMapping
+from clarity_ext.domain.shared_result_file import SharedResultFile
 from clarity_ext.utility.testing_parse_scripts.fake_artifact_factory import FakeArtifactFactory
 
 
@@ -22,11 +25,27 @@ class ContextBuilder:
     def __init__(self):
         self.step_repo = FakeStepRepo()
         self.logger = FakeLogger()
+        self.file_repository = FakeFileRepository()
+        self.os_service = FakeOsService()
+        self.artifact_service = FakeArtifactService()
+        self.file_service = FakeFileService()
+        step_logger_service = StepLoggerService('Step log', self.file_service)
+        self.validation_service = ValidationService(step_logger_service)
         self.context = None
+        self.id_counter = 1
         self._create()
 
     def with_analyte_pair(self, input, output):
         self.step_repo.add_analyte_pair(input, output)
+
+    def with_shared_result_file(self, file_handle, file_name):
+        artifact = SharedResultFile(name=file_handle)
+        self.step_repo.add_shared_result_file(artifact)
+        self.file_repository.add_file(self.id_counter, file_name)
+        existing_file = self.file_repository.file_by_id[self.id_counter]
+        artifact.files.append(existing_file)
+        self.id_counter += 1
+        return artifact
 
     def with_mocked_local_shared_file(self, filename, contents):
         monkey = LocalSharedFilePatcher()
@@ -36,19 +55,13 @@ class ContextBuilder:
     def _create(self):
         session = None
         clarity_service = None
-        file_repository = None
         current_user = None
-        validation_service = None
         dilution_service = None
-        os_service = OSService()
         process_service = ProcessService()
         artifact_service = ArtifactService(self.step_repo)
-        file_service = FileService(
-            artifact_service, file_repository, False,
-            os_service, uploaded_to_stdout=False, disable_commits=True)
-        self.context = ExtensionContext(session, artifact_service, file_service, current_user,
+        self.context = ExtensionContext(session, artifact_service, self.file_service, current_user,
                                 self.logger, self.step_repo, clarity_service,
-                                dilution_service, process_service, validation_service,
+                                dilution_service, process_service, self.validation_service,
                                 test_mode=False, disable_commits=True)
 
 
@@ -92,6 +105,9 @@ class FakeStepRepo:
     def get_process(self):
         return Process(None, "24-1234", self.user, dict(), "http://not-avail")
 
+    def add_shared_result_file(self, f):
+        self._shared_files.append((None, f))
+
 
 class LocalSharedFilePatcher:
     """
@@ -116,9 +132,54 @@ class LocalSharedFilePatcher:
 class FakeLogger:
     def __init__(self):
         self.warnings = list()
+        self.errors = list()
 
     def warning(self, text):
         self.warnings.append(text)
 
+    def error(self, text):
+        self.errors.append(text)
+
     def log(self, text):
+        pass
+
+
+class FakeFileRepository:
+    def __init__(self):
+        self.file_by_id = dict()
+
+    def add_file(self, id, filename):
+        file = FakeFile(id=id, filename=filename)
+        self.file_by_id[id] = file
+
+
+class FakeFile:
+    """
+    Represent a genologics File object
+    """
+    def __init__(self, id, filename=None):
+        self.id = id
+        self.original_location = filename
+        self.api_resource = None
+        self.uri = r'www.something/{}'.format(filename)
+
+
+class FakeOsService(object):
+    def exists(self, path):
+        return True
+
+    def rmtree(self, path):
+        pass
+
+    def makedirs(self, path):
+        pass
+
+
+class FakeArtifactService(object):
+    def shared_files(self):
+        return list()
+
+
+class FakeFileService(object):
+    def local_shared_file_search_or_create(self, file_name, extension, mode, modify_attached, filename):
         pass


### PR DESCRIPTION
Purpose:
By using the context validation service, logging can be directed to separate warning and error files. The idea is that the user may see from the mere existence of a warning file if there is warnings. The existence of a warning file is here kind of a proxy for a popup. The "directed" logging has been implemented in the framework for quite some time but has not yet been adapted very much in scripts. In this PR, this "directed" logging is made more available to use in scripts. 

In addition, enhance the test framework for parsing scripts to make it possible to include logging in testing. 