### PR TITLE
lims-0, Handle accumulated results on batches

### DIFF
--- a/clarity_ext/service/dilution/service.py
+++ b/clarity_ext/service/dilution/service.py
@@ -189,6 +189,8 @@ class DilutionSession(object):
             for batch in transfer_batches:
                 batch_handler.handle_batch(batch)
 
+            batch_handler.handle_accumulated_results()
+
         # Push all validation results over to the validation_service
         for batch in transfer_batches:
             self.validation_service.handle_validation(batch.validation_results)
@@ -1068,6 +1070,9 @@ class TransferHandlerBase(object):
 
 class TransferBatchHandlerBase(TransferHandlerBase):
     def handle_batch(self, batch):
+        pass
+
+    def handle_accumulated_results(self):
         pass
 
     def error(self, msg, batch):


### PR DESCRIPTION
Purpose:

The use-case that motivates this new feature is this:

I want to log min and max volumes for for each plate in a dilutions. However, when I do this logging on each batch individually, I get confusing results. Evaporation batches operates on the very same plate as the final batch and looped batches. This causes several log entries for the same plate, each log entry containing just a subset of the samples included in the step.

Here I have added a hook on batch handlers to be executed after all individual batches have been run. 

