### PR TITLE
lims-0, Remove settings for dead volume

### DIFF
--- a/clarity_ext/service/dilution/service.py
+++ b/clarity_ext/service/dilution/service.py
@@ -364,6 +364,7 @@ class SingleTransfer(object):
 
         # In the case of temporary transfers, we keep a pointer to the original for easier calculations
         self.original = None
+        self.main_transfer = None
         self.source_vol_delta = None
 
         # The TransferBatch takes care of marking the transfer as being a part of it
@@ -721,15 +722,7 @@ class DilutionSettings:
     def __init__(self, scale_up_low_volumes=False, concentration_ref=None, include_blanks=False,
                  volume_calc_method=None, make_pools=False, fixed_sample_volume=None,
                  fixed_buffer_volume=None, robotfile_sort_strategy=None,
-                 tube_placement_sort_strategy=None,
-                 ensure_min_volume_for_two_dilutions_in_row=False):
-        """
-        param: ensure_min_volume_for_two_dilutions_in_row:
-        In cases where the next step is another dilution, ensure that there is at least
-        (pipette min volume + waste volume) in the target container.
-        This setting affect evaporations and fixed volume transfer only.
-        """
-        self.ensure_min_volume_for_two_dilutions_in_row = ensure_min_volume_for_two_dilutions_in_row
+                 tube_placement_sort_strategy=None):
         self.scale_up_low_volumes = scale_up_low_volumes
         # TODO: Use py3 enums instead
         if concentration_ref is not None:
@@ -1136,7 +1129,7 @@ class TransferSplitHandlerBase(TransferHandlerBase):
 
         temp_transfer, main_transfer = self._update_source_target_locations(
             dilute_session, transfer, temp_transfer, main_transfer)
-
+        temp_transfer.main_transfer = main_transfer
         return temp_transfer, main_transfer
 
     def run(self, transfer_route_node):


### PR DESCRIPTION
The setting for dead volume is replaced to a separate handler (in
snpseq plugin). The new handler needs a reference to the main transfer (the last transfer acting on end plate)