### PR TITLE
lims-0, Handle file name ref

### DIFF
--- a/clarity_ext/service/file_service.py
+++ b/clarity_ext/service/file_service.py
@@ -107,6 +107,14 @@ class FileService:
         self.os_service.copy_file(downloaded_path, upload_path)
         return upload_path
 
+    def upload_file_name(self, filename):
+        # Before uploading, each file name is updated with the artifact id as prefix
+        # This is the convention build into clarity, making it recognize
+        # a file to be uploaded
+        return "{}_{}".format(
+            self.artifactid_by_filename[filename], filename
+        )
+
     def remove_files(self, file_handle, disabled, exclude_list=None):
         """Removes all files for the particular file handle.
 


### PR DESCRIPTION
Purpose:
Move code from metadata-file creation code to file-service, in order to be able to change it in clims. 