### PR TITLE
Lazy load samples on an artifact

### DIFF
--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -12,14 +12,28 @@ class Analyte(Aliquot):
     in udf_map, so they can be overridden in different installations.
     """
 
-    def __init__(self, api_resource, is_input, id=None, samples=None, name=None, well=None,
-                 is_control=False, udf_map=None, is_from_original=None):
+    def __init__(self,
+                 api_resource,
+                 is_input,
+                 id=None,
+                 samples=None,
+                 name=None,
+                 well=None,
+                 is_control=False,
+                 udf_map=None,
+                 is_from_original=None,
+                 mapper=None):
         """
         Creates an analyte
         """
-        super(self.__class__, self).__init__(api_resource, is_input=is_input, id=id,
-                                             samples=samples, name=name, well=well,
-                                             udf_map=udf_map)
+        super(self.__class__, self).__init__(api_resource,
+                                             is_input=is_input,
+                                             id=id,
+                                             samples=samples,
+                                             name=name,
+                                             well=well,
+                                             udf_map=udf_map,
+                                             mapper=mapper)
         self.is_control = is_control
         self.is_output_from_previous = is_from_original
         self.reagent_labels = None

--- a/clarity_ext/domain/artifact.py
+++ b/clarity_ext/domain/artifact.py
@@ -14,12 +14,22 @@ class Artifact(DomainObjectWithUdfMixin):
     OUTPUT_TYPE_ANALYTE = 2
     OUTPUT_TYPE_SHARED_RESULT_FILE = 3
 
-    def __init__(self, api_resource=None, artifact_id=None, name=None, udf_map=None, is_input=None):
-        super(Artifact, self).__init__(api_resource=api_resource, id=artifact_id, udf_map=udf_map)
+    def __init__(self,
+                 api_resource=None,
+                 artifact_id=None,
+                 name=None,
+                 udf_map=None,
+                 is_input=None,
+                 mapper=None):
+        super(Artifact, self).__init__(
+            api_resource=api_resource,
+            id=artifact_id,
+            udf_map=udf_map)
         self.is_input = is_input
         self.generation_type = None  # Set to PER_INPUT or PER_ALL_INPUTS if applicable
         self._name = name
         self.view_name = name
+        self._mapper = mapper
 
         # NOTE: This is currently only used in tests, so you can't trust that it has been set
         self.pairings = list()
@@ -28,7 +38,8 @@ class Artifact(DomainObjectWithUdfMixin):
             self._set_output_type()
 
     def _set_output_type(self):
-        raise NotImplementedError('Output type {} is not implemented'.format(self.__class__.__name__))
+        raise NotImplementedError(
+            'Output type {} is not implemented'.format(self.__class__.__name__))
 
     @property
     def name(self):

--- a/clarity_ext/domain/result_file.py
+++ b/clarity_ext/domain/result_file.py
@@ -7,19 +7,33 @@ from clarity_ext.domain.udf import UdfMapping
 class ResultFile(Aliquot):
     """Encapsulates a ResultFile in Clarity"""
 
-    def __init__(self, api_resource, is_input, id=None, samples=None, name=None, well=None,
-                 udf_map=None):
+    def __init__(self,
+                 api_resource,
+                 is_input,
+                 id=None,
+                 samples=None,
+                 name=None,
+                 well=None,
+                 udf_map=None,
+                 mapper=None):
         """
         :param api_resource: The original API resource
         :param is_input: True if this is an input analyte, false if not
         :param samples:
         :param name: Name of the result file
         :param well: Well (location, TODO rename) of the result file
-        :param udf_map: A list of UdfMappingInfo objects 
+        :param udf_map: A list of UdfMappingInfo objects
+        :param mapper: A ClarityMapper
         """
         # TODO: Get rid of the api_resource
-        super(self.__class__, self).__init__(api_resource, is_input=is_input, id=id,
-                samples=samples, name=name, well=well, udf_map=udf_map)
+        super(self.__class__, self).__init__(api_resource,
+                                             is_input=is_input,
+                                             id=id,
+                                             samples=samples,
+                                             name=name,
+                                             well=well,
+                                             udf_map=udf_map,
+                                             mapper=mapper)
         self.is_control = False
 
     def _set_output_type(self):

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -26,7 +26,6 @@ class StepRepository(object):
         self.session = session
         self.clarity_mapper = clarity_mapper
 
-
     def all_artifacts(self):
         """
         Fetches all artifacts from the input output map, wraps them in to a domain object.
@@ -49,6 +48,7 @@ class StepRepository(object):
         for input, output in input_output_maps:
             artifact_keys.add(input["uri"])
             artifact_keys.add(output["uri"])
+
         artifacts = self.session.api.get_batch(artifact_keys)
         artifacts_by_uri = {artifact.uri: artifact for artifact in artifacts}
         for input, output in input_output_maps:
@@ -70,7 +70,7 @@ class StepRepository(object):
         for input_res, output_res in input_output_maps:
             input, output = self._wrap_input_output(
                 input_res, output_res, container_repo, process_type)
-            # Check if we already have an output with this id, and use that instead in that case:
+
             if output.id in outputs_by_id:
                 output = outputs_by_id[output.id]
             ret.append((input, output))
@@ -88,9 +88,18 @@ class StepRepository(object):
         output_resource = output_info["uri"]
         output_gen_type = output_info["output-generation-type"]
         input = self._wrap_artifact(
-            input_resource, container_repo, gen_type="Input", is_input=True, process_type=process_type)
-        output = self._wrap_artifact(output_resource, container_repo,
-                                     gen_type=output_gen_type, is_input=False, process_type=process_type)
+            input_resource,
+            container_repo,
+            gen_type="Input",
+            is_input=True,
+            process_type=process_type)
+
+        output = self._wrap_artifact(
+            output_resource,
+            container_repo,
+            gen_type=output_gen_type,
+            is_input=False,
+            process_type=process_type)
 
         if output_gen_type == "PerInput":
             output.generation_type = Artifact.PER_INPUT
@@ -116,6 +125,7 @@ class StepRepository(object):
         Wraps an artifact in a domain object, if one exists. The domain objects provide logic
         convenient methods for working with the domain object in extensions.
         """
+
         if artifact.type == "Analyte":
             wrapped = self.clarity_mapper.analyte_create_object(
                 artifact, is_input, container_repo, process_type)
@@ -123,7 +133,8 @@ class StepRepository(object):
             wrapped = self.clarity_mapper.result_file_create_object(
                 artifact, is_input, container_repo, process_type)
         elif artifact.type == "ResultFile" and gen_type == "PerAllInputs":
-            wrapped = SharedResultFile.create_from_rest_resource(artifact, process_type)
+            wrapped = SharedResultFile.create_from_rest_resource(
+                artifact, process_type)
         else:
             raise Exception("Unknown type and gen_type combination {}, {}".format(
                 artifact.type, gen_type))


### PR DESCRIPTION
Don't load all samples when creating the domain object version of an
Artifact. This was the reason for extremely long running scripts
including pools, as we are not batch fetching the samples.

A further improvement would batch fetch also (see the samples property
on the Aliquot).