### PR TITLE
Develop 1171, fix qc flag bug

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -270,6 +270,21 @@ class ExtensionContext(object):
         # commit again.
         self._update_queue.clear()
 
+    def commit_step_log_only(self):
+        log_file_names = self.validation_service.log_file_names
+        self.file_service.commit_selective_files(self.disable_commits, log_file_names)
+        self._update_queue.clear()
+
+    def validate_xml_concordance(self):
+        # Ensure cache is filled
+        self.artifact_service.all_artifacts()
+        error_str = self.step_repo.xml_discordance_string()
+        if len(error_str) > 0:
+            error = ValidationException(error_str, ValidationType.ERROR)
+            self.validation_service.handle_single_validation(error)
+            raise AssertionError('Stateful and stateless xml representations are not equal!'
+                                 'Results are written to step log')
+
     @lazyprop
     def current_process_type(self):
         # TODO: Hang this on the process object

--- a/clarity_ext/domain/aliquot.py
+++ b/clarity_ext/domain/aliquot.py
@@ -34,6 +34,8 @@ class Aliquot(Artifact):
         else:
             self.container = None
         self.is_from_original = False
+        if qc_flag is None:
+            qc_flag = self.QC_FLAG_UNKNOWN
         self.qc_flag = qc_flag
 
     def set_qc_passed(self):

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -62,10 +62,10 @@ class StepRepository(object):
         # that we create only one artifact domain object in this case:
         outputs_by_id = dict()
         container_repo = ContainerRepository()
-        for genologics_input, genologics_output, output_generation_type in wrappable_pairs:
+        for raw_input, raw_output, output_generation_type in wrappable_pairs:
             input, output = self._wrap_input_output(
-                genologics_input,
-                genologics_output,
+                raw_input,
+                raw_output,
                 container_repo,
                 process_type,
                 output_generation_type
@@ -186,7 +186,7 @@ class WrappablePairs(object):
         input  # genologics Artifact, either stateful or stateless
         output  # genologics Artifact
 
-    The validation compares the stateless and statefull xml representation,
+    The validation compares the stateless and stateful xml representation,
     and discards any discrepancies in the qc-flag
     """
 

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 import xml.etree.ElementTree as ET
+from clarity_ext.utility.xml_comparison import ComparableXml
 from clarity_ext.domain.artifact import Artifact
 from clarity_ext.domain.shared_result_file import SharedResultFile
 from clarity_ext.repository.container_repository import ContainerRepository
@@ -289,7 +290,7 @@ class Pair(namedtuple('Pair', ['input', 'output', 'output_generation_type', 'sta
 
     def validate(self, api):
         errors = list()
-        if not api.is_equal(
+        if not self._is_equal(
                 self.input.stateless_representation,
                 self.input.stateful_representation,
                 exclude_tag='qc-flag'
@@ -299,7 +300,7 @@ class Pair(namedtuple('Pair', ['input', 'output', 'output_generation_type', 'sta
                 self.input.stateful_representation
             ))
 
-        if not api.is_equal(
+        if not self._is_equal(
             self.output.stateless_representation,
             self.output.stateful_representation,
             exclude_tag='qc-flag'
@@ -309,6 +310,11 @@ class Pair(namedtuple('Pair', ['input', 'output', 'output_generation_type', 'sta
                 self.output.stateful_representation
             ))
         return errors
+
+    def _is_equal(self, entity1, entity2, exclude_tag=None):
+        c1 = ComparableXml(ET.tostring(entity1.root), exclude_tag=exclude_tag)
+        c2 = ComparableXml(ET.tostring(entity2.root), exclude_tag=exclude_tag)
+        return c1.tostring() == c2.tostring()
 
 
 class XmlDiscordanceError(Exception):

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -183,12 +183,16 @@ class WrappablePairs(object):
     MODE_STATEFUL = "stateful"
 
     def __init__(self, session, input_output_maps, state_mode):
+        # Note, the force flag should be set to False as soon as the test period is over!
+        # Develop-1177
+        self.force = True
         self.session = session
         self.input_output_maps = input_output_maps
         self.state_mode = state_mode
         self.pairs = list()
         stateful_artifacts = self._fetch_stateful()
         stateless_artifacts = self._fetch_stateless()
+
         self.pairs = self._assemble_pairs(stateful_artifacts, stateless_artifacts)
 
     def __iter__(self):
@@ -236,7 +240,7 @@ class WrappablePairs(object):
             artifact_keys.add(input["uri"])
             artifact_keys.add(output["uri"])
 
-        return self.session.api.get_batch(artifact_keys)
+        return self.session.api.get_batch(artifact_keys, force=self.force)
 
     def _fetch_stateless(self):
         artifact_keys = set()
@@ -246,7 +250,7 @@ class WrappablePairs(object):
             artifact_keys.add(stateless_input)
             artifact_keys.add(stateless_output)
 
-        return self.session.api.get_batch(artifact_keys)
+        return self.session.api.get_batch(artifact_keys, force=self.force)
 
 
 class Pair(namedtuple('Pair', ['input', 'output', 'output_generation_type', 'state_mode'])):

--- a/clarity_ext/service/artifact_service.py
+++ b/clarity_ext/service/artifact_service.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from clarity_ext.domain import *
 from clarity_ext.domain.shared_result_file import SharedResultFile
 from clarity_ext.repository import StepRepository
-from clarity_ext import ClaritySession
+from clarity_ext.clarity import ClaritySession
 
 
 class ArtifactService:

--- a/clarity_ext/service/file_service.py
+++ b/clarity_ext/service/file_service.py
@@ -240,7 +240,6 @@ class FileService:
 
     def _commit_file(self, disable_commits, artifact_id, file_name):
         """Copies files in the upload queue to the server"""
-        print('file name: {}'.format(file_name))
         if disable_commits:
             self.logger.info("Uploading (disabled) file: {}".format(os.path.abspath(file_name)))
         else:

--- a/clarity_ext/service/file_service.py
+++ b/clarity_ext/service/file_service.py
@@ -221,22 +221,40 @@ class FileService:
     def commit(self, disable_commits):
         """Copies files in the upload queue to the server"""
         self.close_local_shared_files()
+        for artifact_id, file_name in self._file_associations:
+            self._commit_file(disable_commits, artifact_id, file_name)
+
+    def commit_selective_files(self, disable_commits, file_names):
+        self.close_local_shared_files()
+        for artifact_id, file_name in self._file_associations:
+            if file_name in file_names:
+                self._commit_file(disable_commits, artifact_id, file_name)
+
+    @property
+    def _file_associations(self):
+        associations = list()
         for artifact_id in self.os_service.listdir(self.upload_queue_path):
             for file_name in self.os_service.listdir(os.path.join(self.upload_queue_path, artifact_id)):
-                if disable_commits:
-                    self.logger.info("Uploading (disabled) file: {}".format(os.path.abspath(file_name)))
+                associations.append((artifact_id, file_name))
+        return associations
+
+    def _commit_file(self, disable_commits, artifact_id, file_name):
+        """Copies files in the upload queue to the server"""
+        print('file name: {}'.format(file_name))
+        if disable_commits:
+            self.logger.info("Uploading (disabled) file: {}".format(os.path.abspath(file_name)))
+        else:
+            artifact = utils.single([shared_file for shared_file in self.artifact_service.shared_files()
+                                     if shared_file.id == artifact_id])
+            local_file = os.path.join(self.upload_queue_path, artifact_id, file_name)
+            self.logger.info("Uploading file {}".format(local_file))
+            try:
+                self.session.api.upload_new_file(artifact.api_resource, local_file)
+            except requests.HTTPError as e:
+                if "UNDER_REVIEW" in str(e):
+                    self.logger.error("Not able to upload step log as some of the samples are in review")
                 else:
-                    artifact = utils.single([shared_file for shared_file in self.artifact_service.shared_files()
-                                             if shared_file.id == artifact_id])
-                    local_file = os.path.join(self.upload_queue_path, artifact_id, file_name)
-                    self.logger.info("Uploading file {}".format(local_file))
-                    try:
-                        self.session.api.upload_new_file(artifact.api_resource, local_file)
-                    except requests.HTTPError as e:
-                        if "UNDER_REVIEW" in str(e):
-                            self.logger.error("Not able to upload step log as some of the samples are in review")
-                        else:
-                            raise e
+                    raise e
 
     def _split_file_name(self, name):
         m = re.match(self.SERVER_FILE_NAME_PATTERN, name)

--- a/clarity_ext/service/step_logger_service.py
+++ b/clarity_ext/service/step_logger_service.py
@@ -30,7 +30,7 @@ class StepLoggerService(object):
         self.NEW_LINE = "\r\n"
 
     @property
-    def filename_w_extension(self):
+    def filename_with_extension(self):
         return '{}.{}'.format(self.filename, self.extension)
 
     @lazyprop
@@ -111,11 +111,11 @@ class AggregatedStepLoggerService:
     @property
     def log_file_names(self):
         names = list()
-        names.append(self.default_step_logger_service.filename_w_extension)
+        names.append(self.default_step_logger_service.filename_with_extension)
         if self.warnings_step_logger_service is not None:
-            names.append(self.warnings_step_logger_service.filename_w_extension)
+            names.append(self.warnings_step_logger_service.filename_with_extension)
         if self.errors_step_logger_service is not None:
-            names.append(self.errors_step_logger_service.filename_w_extension)
+            names.append(self.errors_step_logger_service.filename_with_extension)
         return names
 
     def error(self, msg):

--- a/clarity_ext/service/step_logger_service.py
+++ b/clarity_ext/service/step_logger_service.py
@@ -29,6 +29,10 @@ class StepLoggerService(object):
         # TODO: This should be configurable.
         self.NEW_LINE = "\r\n"
 
+    @property
+    def filename_w_extension(self):
+        return '{}.{}'.format(self.filename, self.extension)
+
     @lazyprop
     def step_log(self):
         try:
@@ -103,6 +107,16 @@ class AggregatedStepLoggerService:
         self.step_logger_name = default_step_logger_service.file_handle
         self.warnings_step_logger_service = warnings_step_logger_service
         self.errors_step_logger_service = errors_step_logger_service
+
+    @property
+    def log_file_names(self):
+        names = list()
+        names.append(self.default_step_logger_service.filename_w_extension)
+        if self.warnings_step_logger_service is not None:
+            names.append(self.warnings_step_logger_service.filename_w_extension)
+        if self.errors_step_logger_service is not None:
+            names.append(self.errors_step_logger_service.filename_w_extension)
+        return names
 
     def error(self, msg):
         self.default_step_logger_service.error(msg)

--- a/clarity_ext/service/validation_service.py
+++ b/clarity_ext/service/validation_service.py
@@ -18,6 +18,10 @@ class ValidationService:
     def add_separate_error_step_log(self, step_logger_service):
         self.step_logger_service.errors_step_logger_service = step_logger_service
 
+    @property
+    def log_file_names(self):
+        return self.step_logger_service.log_file_names
+
     def handle_validation(self, results, tailored_error_message=None):
         """
         Pushes validation results to the logging framework

--- a/clarity_ext/utility/xml_comparison.py
+++ b/clarity_ext/utility/xml_comparison.py
@@ -1,0 +1,31 @@
+import re
+import xml.etree.ElementTree as ET
+
+
+class ComparableXml(object):
+    def __init__(self, xml_string, exclude_tag=None):
+        root = ET.fromstring(xml_string)
+        self._set_sorted_rec(root)
+        if exclude_tag:
+            self._exclude_tag(root, exclude_tag)
+        self.root = root
+
+    def _exclude_tag(self, root, exclude):
+        for el in root.findall(exclude):
+            root.remove(el)
+
+    def _set_sorted_rec(self, element):
+        for sub_element in element:
+            self._set_sorted_rec(sub_element)
+        element[:] = sorted(element, key=self._element_sort_key)
+
+    def _element_sort_key(self, el):
+        attrib = sorted(el.attrib.items())
+        key = el.tag
+        for attr, value in attrib:
+            key += value
+        return key
+
+    def tostring(self):
+        # Remove all whitespaces in string. Indentation in output cause problems.
+        return re.sub(r'\s+', '', ET.tostring(self.root))

--- a/clarity_ext/utility/xml_comparison.py
+++ b/clarity_ext/utility/xml_comparison.py
@@ -28,4 +28,4 @@ class ComparableXml(object):
 
     def tostring(self):
         # Remove all whitespaces in string. Indentation in output cause problems.
-        return re.sub(r'\s+', '', ET.tostring(self.root))
+        return re.sub(r'\s+', '', ET.tostring(self.root, encoding='unicode'))

--- a/resources/different_outside_qc_flag/artifact1.xml
+++ b/resources/different_outside_qc_flag/artifact1.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<art:artifact xmlns:udf="http://genologics.com/ri/userdefined" xmlns:file="http://genologics.com/ri/file" xmlns:art="http://genologics.com/ri/artifact" uri="https://dev-server/api/v2/artifacts/92-189520?state=107035" limsid="92-189520">
+    <name>Ladder1</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="https://dev-server/api/v2/processes/24-61209" limsid="24-61209"/>
+    <qc-flag>UNKNOWN</qc-flag>
+    <location>
+        <container uri="https://dev-server/api/v2/containers/27-8244" limsid="27-8244"/>
+        <value>C:3</value>
+    </location>
+    <sample uri="https://dev-server/api/v2/samples/51C-2471" limsid="51C-2471"/>
+    <control-type uri="https://dev-server/api/v2/controltypes/51"/>
+    <workflow-stages/>
+</art:artifact>

--- a/resources/different_outside_qc_flag/artifact2.xml
+++ b/resources/different_outside_qc_flag/artifact2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<art:artifact xmlns:udf="http://genologics.com/ri/userdefined" xmlns:file="http://genologics.com/ri/file" xmlns:art="http://genologics.com/ri/artifact" uri="https://dev-server/api/v2/artifacts/92-189520?state=107035" limsid="92-189520">
+    <name>Ladder2</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="https://dev-server/api/v2/processes/24-61209" limsid="24-61209"/>
+    <qc-flag>PASSED</qc-flag>
+    <location>
+        <container uri="https://dev-server/api/v2/containers/27-8244" limsid="27-8244"/>
+        <value>C:3</value>
+    </location>
+    <sample uri="https://dev-server/api/v2/samples/51C-2471" limsid="51C-2471"/>
+    <control-type uri="https://dev-server/api/v2/controltypes/51"/>
+    <workflow-stages/>
+</art:artifact>

--- a/resources/different_qc_flag/artifact1.xml
+++ b/resources/different_qc_flag/artifact1.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<art:artifact xmlns:udf="http://genologics.com/ri/userdefined" xmlns:file="http://genologics.com/ri/file" xmlns:art="http://genologics.com/ri/artifact" uri="https://dev-server/api/v2/artifacts/92-189520?state=107035" limsid="92-189520">
+    <name>Ladder</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="https://dev-server/api/v2/processes/24-61209" limsid="24-61209"/>
+    <qc-flag>UNKNOWN</qc-flag>
+    <location>
+        <container uri="https://dev-server/api/v2/containers/27-8244" limsid="27-8244"/>
+        <value>C:3</value>
+    </location>
+    <sample uri="https://dev-server/api/v2/samples/51C-2471" limsid="51C-2471"/>
+    <control-type uri="https://dev-server/api/v2/controltypes/51"/>
+    <workflow-stages/>
+</art:artifact>

--- a/resources/different_qc_flag/artifact2.xml
+++ b/resources/different_qc_flag/artifact2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<art:artifact xmlns:udf="http://genologics.com/ri/userdefined" xmlns:file="http://genologics.com/ri/file" xmlns:art="http://genologics.com/ri/artifact" uri="https://dev-server/api/v2/artifacts/92-189520?state=107035" limsid="92-189520">
+    <name>Ladder</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="https://dev-server/api/v2/processes/24-61209" limsid="24-61209"/>
+    <qc-flag>PASSED</qc-flag>
+    <location>
+        <container uri="https://dev-server/api/v2/containers/27-8244" limsid="27-8244"/>
+        <value>C:3</value>
+    </location>
+    <sample uri="https://dev-server/api/v2/samples/51C-2471" limsid="51C-2471"/>
+    <control-type uri="https://dev-server/api/v2/controltypes/51"/>
+    <workflow-stages/>
+</art:artifact>

--- a/resources/resource_bag.py
+++ b/resources/resource_bag.py
@@ -1,0 +1,40 @@
+import os
+
+
+def read_binary_file(path):
+    with open(path, 'rb') as f:
+        contents = f.read()
+    return contents
+
+
+def get_directory(sub_dir):
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(this_dir, sub_dir)
+
+
+def get_same_without_qc_flags():
+    ddir = get_directory('same_without_qc_flags')
+    path1 = os.path.join(ddir, 'artifact1.xml')
+    path2 = os.path.join(ddir, 'artifact2.xml')
+    return read_binary_file(path1), read_binary_file(path2)
+
+
+def get_same_but_in_different_order():
+    ddir = get_directory('same_with_different_order')
+    path1 = os.path.join(ddir, 'artifact1.xml')
+    path2 = os.path.join(ddir, 'artifact2.xml')
+    return read_binary_file(path1), read_binary_file(path2)
+
+
+def get_same_pools_with_different_order():
+    ddir = get_directory('same_pools_with_different_order')
+    path1 = os.path.join(ddir, 'artifact1.xml')
+    path2 = os.path.join(ddir, 'artifact2.xml')
+    return read_binary_file(path1), read_binary_file(path2)
+
+
+def get_differeing_qc_flags():
+    ddir = get_directory('different_qc_flag')
+    path1 = os.path.join(ddir, 'artifact1.xml')
+    path2 = os.path.join(ddir, 'artifact2.xml')
+    return read_binary_file(path1), read_binary_file(path2)

--- a/resources/resource_bag.py
+++ b/resources/resource_bag.py
@@ -38,3 +38,10 @@ def get_differeing_qc_flags():
     path1 = os.path.join(ddir, 'artifact1.xml')
     path2 = os.path.join(ddir, 'artifact2.xml')
     return read_binary_file(path1), read_binary_file(path2)
+
+
+def get_different_outside_qc_flag():
+    ddir = get_directory('different_outside_qc_flag')
+    path1 = os.path.join(ddir, 'artifact1.xml')
+    path2 = os.path.join(ddir, 'artifact2.xml')
+    return read_binary_file(path1), read_binary_file(path2)

--- a/resources/same_pools_with_different_order/artifact1.xml
+++ b/resources/same_pools_with_different_order/artifact1.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<art:artifact xmlns:udf="http://genologics.com/ri/userdefined" xmlns:file="http://genologics.com/ri/file" xmlns:art="http://genologics.com/ri/artifact" uri="https://dev-server/api/v2/artifacts/2-139115?state=79916" limsid="2-139115">
+    <name>NovaSeq-RMLD_Pool1_31664_2nM_191212</name>
+    <type>Analyte</type>
+    <output-type>Analyte</output-type>
+    <parent-process uri="https://dev-server/api/v2/processes/122-31664" limsid="122-31664"/>
+    <qc-flag>UNKNOWN</qc-flag>
+    <location>
+        <container uri="https://dev-server/api/v2/containers/27-7054" limsid="27-7054"/>
+        <value>1:1</value>
+    </location>
+    <working-flag>true</working-flag>
+    <sample uri="https://dev-server/api/v2/samples/THO655A14" limsid="THO655A14"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A15" limsid="THO655A15"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A16" limsid="THO655A16"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A17" limsid="THO655A17"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A18" limsid="THO655A18"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A19" limsid="THO655A19"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A20" limsid="THO655A20"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A21" limsid="THO655A21"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A22" limsid="THO655A22"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A23" limsid="THO655A23"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A24" limsid="THO655A24"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A25" limsid="THO655A25"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A26" limsid="THO655A26"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A27" limsid="THO655A27"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A28" limsid="THO655A28"/>
+    <sample uri="https://dev-server/api/v2/samples/6C-2003" limsid="6C-2003"/>
+    <reagent-label name="D702-D506 (TCCGGAGA-TAATCTTA)"/>
+    <reagent-label name="D702-D507 (TCCGGAGA-CAGGACGT)"/>
+    <reagent-label name="D702-D508 (TCCGGAGA-GTACTGAC)"/>
+    <reagent-label name="D703-D501 (CGCTCATT-TATAGCCT)"/>
+    <reagent-label name="D703-D502 (CGCTCATT-ATAGAGGC)"/>
+    <reagent-label name="D703-D503 (CGCTCATT-CCTATCCT)"/>
+    <reagent-label name="D703-D504 (CGCTCATT-GGCTCTGA)"/>
+    <reagent-label name="D703-D505 (CGCTCATT-AGGCGAAG)"/>
+    <reagent-label name="D703-D506 (CGCTCATT-TAATCTTA)"/>
+    <reagent-label name="D703-D507 (CGCTCATT-CAGGACGT)"/>
+    <reagent-label name="D703-D508 (CGCTCATT-GTACTGAC)"/>
+    <reagent-label name="D704-D501 (GAGATTCC-TATAGCCT)"/>
+    <reagent-label name="D704-D502 (GAGATTCC-ATAGAGGC)"/>
+    <reagent-label name="D704-D503 (GAGATTCC-CCTATCCT)"/>
+    <reagent-label name="D704-D504 (GAGATTCC-GGCTCTGA)"/>
+    <control-type uri="https://dev-server/api/v2/controltypes/6"/>
+    <udf:field type="Numeric" name="Target vol. (ul)">20</udf:field>
+    <udf:field type="Numeric" name="Dil. calc. target vol">20</udf:field>
+    <udf:field type="Numeric" name="Current sample volume (ul)">20</udf:field>
+    <udf:field type="Numeric" name="Dil. calc. source vol">0</udf:field>
+    <workflow-stages>
+        <workflow-stage status="IN_PROGRESS" name="SNP&amp;SEQ Denature (NovaSeq) v1" uri="https://dev-server/api/v2/configuration/workflows/701/stages/7149"/>
+        <workflow-stage status="IN_PROGRESS" name="SNP&amp;SEQ Denature (NovaSeq) v1" uri="https://dev-server/api/v2/configuration/workflows/902/stages/8785"/>
+        <workflow-stage status="IN_PROGRESS" name="SNP&amp;SEQ Denature (NovaSeq) v1" uri="https://dev-server/api/v2/configuration/workflows/901/stages/8641"/>
+        <workflow-stage status="IN_PROGRESS" name="SNP&amp;SEQ Denature (NovaSeq) v1" uri="https://dev-server/api/v2/configuration/workflows/851/stages/8404"/>
+    </workflow-stages>
+</art:artifact>

--- a/resources/same_pools_with_different_order/artifact2.xml
+++ b/resources/same_pools_with_different_order/artifact2.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<art:artifact xmlns:udf="http://genologics.com/ri/userdefined" xmlns:file="http://genologics.com/ri/file" xmlns:art="http://genologics.com/ri/artifact" uri="https://dev-server/api/v2/artifacts/2-139115?state=79916" limsid="2-139115">
+    <name>NovaSeq-RMLD_Pool1_31664_2nM_191212</name>
+    <type>Analyte</type>
+    <output-type>Analyte</output-type>
+    <parent-process uri="https://dev-server/api/v2/processes/122-31664" limsid="122-31664"/>
+    <qc-flag>UNKNOWN</qc-flag>
+    <location>
+        <container uri="https://dev-server/api/v2/containers/27-7054" limsid="27-7054"/>
+        <value>1:1</value>
+    </location>
+    <working-flag>true</working-flag>
+    <sample uri="https://dev-server/api/v2/samples/THO655A14" limsid="THO655A14"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A15" limsid="THO655A15"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A16" limsid="THO655A16"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A17" limsid="THO655A17"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A18" limsid="THO655A18"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A19" limsid="THO655A19"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A21" limsid="THO655A21"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A20" limsid="THO655A20"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A22" limsid="THO655A22"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A23" limsid="THO655A23"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A24" limsid="THO655A24"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A25" limsid="THO655A25"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A26" limsid="THO655A26"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A27" limsid="THO655A27"/>
+    <sample uri="https://dev-server/api/v2/samples/THO655A28" limsid="THO655A28"/>
+    <sample uri="https://dev-server/api/v2/samples/6C-2003" limsid="6C-2003"/>
+    <reagent-label name="D702-D506 (TCCGGAGA-TAATCTTA)"/>
+    <reagent-label name="D702-D507 (TCCGGAGA-CAGGACGT)"/>
+    <reagent-label name="D702-D508 (TCCGGAGA-GTACTGAC)"/>
+    <reagent-label name="D703-D501 (CGCTCATT-TATAGCCT)"/>
+    <reagent-label name="D703-D502 (CGCTCATT-ATAGAGGC)"/>
+    <reagent-label name="D703-D503 (CGCTCATT-CCTATCCT)"/>
+    <reagent-label name="D703-D505 (CGCTCATT-AGGCGAAG)"/>
+    <reagent-label name="D703-D504 (CGCTCATT-GGCTCTGA)"/>
+    <reagent-label name="D703-D506 (CGCTCATT-TAATCTTA)"/>
+    <reagent-label name="D703-D507 (CGCTCATT-CAGGACGT)"/>
+    <reagent-label name="D703-D508 (CGCTCATT-GTACTGAC)"/>
+    <reagent-label name="D704-D501 (GAGATTCC-TATAGCCT)"/>
+    <reagent-label name="D704-D502 (GAGATTCC-ATAGAGGC)"/>
+    <reagent-label name="D704-D503 (GAGATTCC-CCTATCCT)"/>
+    <reagent-label name="D704-D504 (GAGATTCC-GGCTCTGA)"/>
+    <control-type uri="https://dev-server/api/v2/controltypes/6"/>
+    <udf:field type="Numeric" name="Target vol. (ul)">20</udf:field>
+    <udf:field type="Numeric" name="Dil. calc. target vol">20</udf:field>
+    <udf:field type="Numeric" name="Current sample volume (ul)">20</udf:field>
+    <udf:field type="Numeric" name="Dil. calc. source vol">0</udf:field>
+    <workflow-stages>
+        <workflow-stage status="IN_PROGRESS" name="SNP&amp;SEQ Denature (NovaSeq) v1" uri="https://dev-server/api/v2/configuration/workflows/701/stages/7149"/>
+        <workflow-stage status="IN_PROGRESS" name="SNP&amp;SEQ Denature (NovaSeq) v1" uri="https://dev-server/api/v2/configuration/workflows/902/stages/8785"/>
+        <workflow-stage status="IN_PROGRESS" name="SNP&amp;SEQ Denature (NovaSeq) v1" uri="https://dev-server/api/v2/configuration/workflows/901/stages/8641"/>
+        <workflow-stage status="IN_PROGRESS" name="SNP&amp;SEQ Denature (NovaSeq) v1" uri="https://dev-server/api/v2/configuration/workflows/851/stages/8404"/>
+    </workflow-stages>
+</art:artifact>

--- a/resources/same_with_different_order/artifact1.xml
+++ b/resources/same_with_different_order/artifact1.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<art:artifact xmlns:udf="http://genologics.com/ri/userdefined" xmlns:file="http://genologics.com/ri/file" xmlns:art="http://genologics.com/ri/artifact" uri="https://dev-server/api/v2/artifacts/92-189520?state=107035" limsid="92-189520">
+    <name>Ladder</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="https://dev-server/api/v2/processes/24-61209" limsid="24-61209"/>
+    <location>
+        <container uri="https://dev-server/api/v2/containers/27-8244" limsid="27-8244"/>
+        <value>C:3</value>
+    </location>
+    <sample uri="https://dev-server/api/v2/samples/51C-2471" limsid="51C-2471"/>
+    <control-type uri="https://dev-server/api/v2/controltypes/51"/>
+    <workflow-stages/>
+</art:artifact>

--- a/resources/same_with_different_order/artifact2.xml
+++ b/resources/same_with_different_order/artifact2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<art:artifact xmlns:udf="http://genologics.com/ri/userdefined" xmlns:file="http://genologics.com/ri/file" xmlns:art="http://genologics.com/ri/artifact" uri="https://dev-server/api/v2/artifacts/92-189520?state=107035" limsid="92-189520">
+    <name>Ladder</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="https://dev-server/api/v2/processes/24-61209" limsid="24-61209"/>
+    <sample uri="https://dev-server/api/v2/samples/51C-2471" limsid="51C-2471"/>
+    <location>
+        <value>C:3</value>
+        <container uri="https://dev-server/api/v2/containers/27-8244" limsid="27-8244"/>
+    </location>
+    <control-type uri="https://dev-server/api/v2/controltypes/51"/>
+    <workflow-stages/>
+</art:artifact>

--- a/resources/same_without_qc_flags/artifact1.xml
+++ b/resources/same_without_qc_flags/artifact1.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<art:artifact xmlns:udf="http://genologics.com/ri/userdefined" xmlns:file="http://genologics.com/ri/file" xmlns:art="http://genologics.com/ri/artifact" uri="https://dev-server/api/v2/artifacts/92-189520?state=107035" limsid="92-189520">
+    <name>Ladder</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="https://dev-server/api/v2/processes/24-61209" limsid="24-61209"/>
+    <location>
+        <container uri="https://dev-server/api/v2/containers/27-8244" limsid="27-8244"/>
+        <value>C:3</value>
+    </location>
+    <sample uri="https://dev-server/api/v2/samples/51C-2471" limsid="51C-2471"/>
+    <control-type uri="https://dev-server/api/v2/controltypes/51"/>
+    <workflow-stages/>
+</art:artifact>

--- a/resources/same_without_qc_flags/artifact2.xml
+++ b/resources/same_without_qc_flags/artifact2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<art:artifact xmlns:udf="http://genologics.com/ri/userdefined" xmlns:file="http://genologics.com/ri/file" xmlns:art="http://genologics.com/ri/artifact" uri="https://dev-server/api/v2/artifacts/92-189520?state=107035" limsid="92-189520">
+    <name>Ladder</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="https://dev-server/api/v2/processes/24-61209" limsid="24-61209"/>
+    <location>
+        <container uri="https://dev-server/api/v2/containers/27-8244" limsid="27-8244"/>
+        <value>C:3</value>
+    </location>
+    <sample uri="https://dev-server/api/v2/samples/51C-2471" limsid="51C-2471"/>
+    <control-type uri="https://dev-server/api/v2/controltypes/51"/>
+    <workflow-stages/>
+</art:artifact>

--- a/test/unit/clarity_ext/test_xml_comparison.py
+++ b/test/unit/clarity_ext/test_xml_comparison.py
@@ -4,6 +4,7 @@ from resources.resource_bag import get_same_without_qc_flags
 from resources.resource_bag import get_same_but_in_different_order
 from resources.resource_bag import get_same_pools_with_different_order
 from resources.resource_bag import get_differeing_qc_flags
+from resources.resource_bag import get_different_outside_qc_flag
 
 
 class TestXmlComparison(unittest.TestCase):
@@ -30,6 +31,12 @@ class TestXmlComparison(unittest.TestCase):
         str1 = self._parse(xml1)
         str2 = self._parse(xml2)
         self.assertEqual(str1, str2)
+
+    def test_different_xml__is_discovered(self):
+        xml1, xml2 = get_different_outside_qc_flag()
+        str1 = self._parse(xml1)
+        str2 = self._parse(xml2)
+        self.assertNotEqual(str1, str2)
 
     def _parse(self, resource):
         comparable = ComparableXml(resource, exclude_tag='qc-flag')

--- a/test/unit/clarity_ext/test_xml_comparison.py
+++ b/test/unit/clarity_ext/test_xml_comparison.py
@@ -1,0 +1,36 @@
+import unittest
+from clarity_ext.utility.xml_comparison import ComparableXml
+from resources.resource_bag import get_same_without_qc_flags
+from resources.resource_bag import get_same_but_in_different_order
+from resources.resource_bag import get_same_pools_with_different_order
+from resources.resource_bag import get_differeing_qc_flags
+
+
+class TestXmlComparison(unittest.TestCase):
+    def test_identical_xmls(self):
+        xml1, xml2 = get_same_without_qc_flags()
+        str1 = self._parse(xml1)
+        str2 = self._parse(xml2)
+        self.assertEqual(str1, str2)
+
+    def test_same_but_different_order(self):
+        xml1, xml2 = get_same_but_in_different_order()
+        str1 = self._parse(xml1)
+        str2 = self._parse(xml2)
+        self.assertEqual(str1, str2)
+
+    def test_pools_in_different_order(self):
+        xml1, xml2 = get_same_pools_with_different_order()
+        str1 = self._parse(xml1)
+        str2 = self._parse(xml2)
+        self.assertEqual(str1, str2)
+
+    def test_exclude_qc_flag(self):
+        xml1, xml2 = get_differeing_qc_flags()
+        str1 = self._parse(xml1)
+        str2 = self._parse(xml2)
+        self.assertEqual(str1, str2)
+
+    def _parse(self, resource):
+        comparable = ComparableXml(resource, exclude_tag='qc-flag')
+        return comparable.tostring()


### PR DESCRIPTION
This PR can be merged when
* Commit f64e022 is re-introduced (because it has been reverted as now)
* Clarity-ext has been converted to python 3
* it is rebased according to python 3 conversion.

Purpose:
Fetch all artifacts without the state argument in the uri, so that artifacts are fetched as presented at UI. This will prevent some bugs and hack code.

As a precaution, also fetch artifacts in the previous way, including the state argument, then make a comparison of stateful and stateless xml represenation of the artifacts. In this way, each fetched artifact is validated. This validation is thought to exist for a limited period of time, because there is a performance loss in fetching the double amount of data for each step. 

Any such validation error are to be pushed into the step log and to the underlying system log. 

More information may be found at https://snpseq.atlassian.net/browse/DEVELOP-1177

Details:
A validation error from xml discordance can't be pushed right away, because when it happens the step log is not yet instantiated.

I made some refactoring in how the commit works after an error occurred.
1. Ensure only step log, errors and warnings are committed after an error occurred.
2. Any type of unexpected error is pushed to the step log and the underlying system log
Up to now, files may have been committed even after an error occurred, and in some cases also analytes. This is of course not good, although (as I understand it) the lab has the procedure to completely start a step from scratch after an error. 
