### PR TITLE
Re-enable "Add qc flag to aliquot"

### DIFF
--- a/clarity_ext/domain/aliquot.py
+++ b/clarity_ext/domain/aliquot.py
@@ -10,14 +10,18 @@ class Aliquot(Artifact):
     of the original for example. Or, in the case of ResultFile, only a measurement of the original.
     """
 
+    QC_FLAG_PASSED = 'PASSED'
+    QC_FLAG_FAILED = 'FAILED'
+    QC_FLAG_UNKNOWN = 'UNKNOWN'
+
     def __init__(self, api_resource, is_input, id=None, samples=None, name=None,
-                 well=None, udf_map=None, mapper=None):
+                 well=None, qc_flag=None, udf_map=None, mapper=None):
         super(Aliquot, self).__init__(api_resource=api_resource,
                                       artifact_id=id,
                                       name=name,
                                       udf_map=udf_map,
                                       is_input=is_input,
-                                      mapper=mapper)
+                                      mapper=mapper,)
         # NOTE: This is a quick fix for extremely slow loading of large pools
         if samples:
             self._samples_require_initializing = not isinstance(samples[0], Sample)
@@ -30,6 +34,13 @@ class Aliquot(Artifact):
         else:
             self.container = None
         self.is_from_original = False
+        self.qc_flag = qc_flag
+
+    def set_qc_passed(self):
+        self.qc_flag = self.QC_FLAG_PASSED
+
+    def set_qc_failed(self):
+        self.qc_flag = self.QC_FLAG_FAILED
 
     @property
     def samples(self):

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -19,6 +19,7 @@ class Analyte(Aliquot):
                  samples=None,
                  name=None,
                  well=None,
+                 qc_flag=None,
                  is_control=False,
                  udf_map=None,
                  is_from_original=None,
@@ -32,6 +33,7 @@ class Analyte(Aliquot):
                                              samples=samples,
                                              name=name,
                                              well=well,
+                                             qc_flag=qc_flag,
                                              udf_map=udf_map,
                                              mapper=mapper)
         self.is_control = is_control

--- a/clarity_ext/domain/result_file.py
+++ b/clarity_ext/domain/result_file.py
@@ -14,6 +14,7 @@ class ResultFile(Aliquot):
                  samples=None,
                  name=None,
                  well=None,
+                 qc_flag=None,
                  udf_map=None,
                  mapper=None):
         """
@@ -32,6 +33,7 @@ class ResultFile(Aliquot):
                                              samples=samples,
                                              name=name,
                                              well=well,
+                                             qc_flag=qc_flag,
                                              udf_map=udf_map,
                                              mapper=mapper)
         self.is_control = False

--- a/clarity_ext/domain/udf.py
+++ b/clarity_ext/domain/udf.py
@@ -79,12 +79,15 @@ class DomainObjectWithUdfMixin(DomainObjectMixin):
         if self.name != self.api_resource.name:
             attrib_updates = True
 
+        if self.qc_flag != self.api_resource.qc_flag:
+            attrib_updates = True
         if len(updated_fields) == 0 and not attrib_updates:
             return None
         else:
             for udf_info in updated_fields:
                 new_api_resource.udf[udf_info.key] = udf_info.value
             new_api_resource.name = self.name
+            new_api_resource.qc_flag = self.qc_flag
             return new_api_resource
 
 

--- a/clarity_ext/mappers/clarity_mapper.py
+++ b/clarity_ext/mappers/clarity_mapper.py
@@ -176,6 +176,7 @@ class ClarityMapper(object):
                          samples=resource.samples,
                          name=resource.name,
                          well=well,
+                         qc_flag=resource.qc_flag,
                          udf_map=udf_map,
                          mapper=self)
         return ret

--- a/clarity_ext/service/artifact_service.py
+++ b/clarity_ext/service/artifact_service.py
@@ -44,8 +44,10 @@ class ArtifactService:
         Returns all aliquots in a step as an artifact pair (input/output)
         """
         pairs = self.all_artifacts()
-        aliquots_only = [pair for pair in pairs if isinstance(pair[0], Aliquot) and
-                               isinstance(pair[1], Aliquot)]
+        aliquots_only = [
+            pair for pair in pairs
+            if isinstance(pair[0], Aliquot) and isinstance(pair[1], Aliquot)
+        ]
         return [ArtifactPair(i, o) for i, o in aliquots_only]
 
     def all_analyte_pairs(self):

--- a/clarity_ext/utility/testing_parse_scripts/builders.py
+++ b/clarity_ext/utility/testing_parse_scripts/builders.py
@@ -13,6 +13,7 @@ from clarity_ext.service.artifact_service import ArtifactService
 from clarity_ext.domain.process import Process
 from clarity_ext.domain.user import User
 from clarity_ext.domain.udf import UdfMapping
+from clarity_ext.domain.aliquot import Aliquot
 from clarity_ext.domain.shared_result_file import SharedResultFile
 from clarity_ext.utility.testing_parse_scripts.fake_artifact_factory import FakeArtifactFactory
 
@@ -75,16 +76,24 @@ class PairBuilder(object):
         self.target_id = None
         self.target_type = None
         self.pair = None
+        self.qc_flag = Aliquot.QC_FLAG_UNKNOWN
+        self.name = None
 
     def create(self):
         pair = self.artifact_repo.create_pair(
             pos_from=None, pos_to=None, source_id=None, target_id=self.target_id,
             target_type=self.target_type)
         pair.output_artifact.udf_map = UdfMapping(self.output_udf_dict)
+        pair.output_artifact.qc_flag = self.qc_flag
+        pair.output_artifact.name = self.name
+        pair.input_artifact.name = self.name
         self.pair = pair
 
     def with_target_id(self, target_id):
         self.target_id = target_id
+
+    def with_name(self, name):
+        self.name = name
 
     def with_output_udf(self, lims_udf_name, value):
         self.output_udf_dict[lims_udf_name] = value

--- a/clarity_ext/utility/testing_parse_scripts/read_result_file_builder.py
+++ b/clarity_ext/utility/testing_parse_scripts/read_result_file_builder.py
@@ -18,9 +18,10 @@ class ReadResultFileBuilder:
         self.pair_builder = PairBuilder()
         self.extension_type = None
 
-    def create_pair(self, target_artifact_id):
+    def create_pair(self, target_artifact_id, name=None):
         artifact_pair_builder = self.pair_builder
         artifact_pair_builder.with_target_id(target_artifact_id)
+        artifact_pair_builder.with_name(name)
         artifact_pair_builder.create()
         return artifact_pair_builder.pair
 


### PR DESCRIPTION
This commit is generated by "git revert 0d01e08"
This reverts commit 0d01e0857972b9cf0b44e48b695417b7d9c7ac46.

The history of this ticket is:
* Merge PR develop-1001, “Clarity-ext should suport qc flags”
* Revert the above PR, develop-1215, because it introduced a bug, and the solution can’t be reached before the python 3 conversion

Now, I re-enable the PR 1001, by reverting PR develop 1215.