### PR TITLE
Python 3 sort key for container names

### DIFF
--- a/clarity_ext/service/dilution/service.py
+++ b/clarity_ext/service/dilution/service.py
@@ -602,15 +602,33 @@ class SortStrategy:
             # the list starting with an empty string should be sorted first into zip()
             return len(a_list[0])
 
-        strings_in_name = re.split('[-_]*\d+[-_]*', container.name)
-        strings_in_name = list(map(conv_lower, strings_in_name))
-        numbers_in_name = re.split('[-_]*\D+[-_]*', container.name)
-        zip_arg = sorted([numbers_in_name, strings_in_name], key=zip_order)
-        zipped = list(zip(*zip_arg))
-        flatlist = list(chain(*zipped))
-        sortlist_of_strings = [item for item in flatlist if len(item) > 0]
-        sortlist = [container.sort_weight, not container.is_temporary] + list(map(conv_int, sortlist_of_strings))
+        name_sort_array = SortStrategy.create_sort_key_from(container.name)
+        sortlist = [container.sort_weight, not container.is_temporary] + name_sort_array
         return tuple(sortlist)
+
+    @staticmethod
+    def create_sort_key_from(container_name):
+        name_parts = re.split('[-_]+', container_name)
+        name_sort_array = list()
+        for part in name_parts:
+            strings = re.split('\d+', part)
+            numbers = re.split('\D+', part)
+            strings = [s for s in strings if s != '']
+            strings = list(map(lambda x: x.lower(), strings))
+            numbers = [n for n in numbers if n != '']
+            numbers = list(map(lambda x: int(x), numbers))
+            # pad the shortest list
+            if len(strings) > len(numbers):
+                numbers += [0] * (len(strings) - len(numbers))
+
+            if len(numbers) > len(strings):
+                strings += [''] * (len(numbers) - len(strings))
+
+            zipped = list(zip(strings, numbers))
+            flattened = list(chain(*zipped))
+            name_sort_array.extend(flattened)
+
+        return name_sort_array
 
 
 class TubeRackPositioner:

--- a/clarity_ext/service/file_service.py
+++ b/clarity_ext/service/file_service.py
@@ -268,7 +268,7 @@ class FileService:
         full_path = os.path.join(self.temp_path, filename)
         # The file needs to be opened in binary form to ensure that Windows
         # line endings are used if specified
-        with self.os_service.open_file(full_path, 'w') as f:
+        with self.os_service.open_file(full_path, 'w+') as f:
             self.logger.debug("Writing output to {}.".format(full_path))
             f.write(content)
         return full_path

--- a/test/unit/clarity_ext/test_container_sort_key.py
+++ b/test/unit/clarity_ext/test_container_sort_key.py
@@ -25,6 +25,17 @@ class TestPlateSortOrder(unittest.TestCase):
         self.assertEqual("27-8473", platelist[0].name)
         self.assertEqual("Test-RNA1_PL1_org_210428", platelist[1].name)
 
+    def test_create_sort_key_from_with_id(self):
+        assert SortStrategy.create_sort_key_from("24-1234") == ('', 24, '', 1234)
+
+    def test_create_sort_key_from_with_original_expected(self):
+        # Original naming convention when this was implemented
+        assert (SortStrategy.create_sort_key_from("Test-RNA1_PL1_org_210428") ==
+                ('test', 0, 'rna', 1, 'pl', 1, 'org', 0, '', 210428))
+
+    def test_create_sort_key_from_with_original_unexpected_but_documented(self):
+        assert (SortStrategy.create_sort_key_from("2ab1_plate3-210505") ==
+                ('ab', 2, '', 1, 'plate', 3, '', 210505))
 
 class Dummy:
     pass

--- a/test/unit/clarity_ext/test_container_sort_key.py
+++ b/test/unit/clarity_ext/test_container_sort_key.py
@@ -1,0 +1,30 @@
+import unittest
+from clarity_ext.service.dilution.service import SortStrategy
+
+
+class TestPlateSortOrder(unittest.TestCase):
+    def create_container(self, name, is_temporary):
+        c = Dummy()
+        c.name = name
+        c.is_temporary = is_temporary
+        c.sort_weight = 0
+        return c
+
+    def test_sort_key_for_plate(self):
+        platename = "code-123_Plate432_org_171010"
+        c = self.create_container(platename, False)
+        sortlist = SortStrategy.container_sort_key(c)
+        self.assertEqual((0, True, 'code', 0, '', 123, 'plate', 432, 'org', 0, '', 171010), sortlist)
+
+    def test_validation_error__with_one_lims_id_and_one_ordinary_name(self):
+        name1 = "27-8473"
+        name2 = "Test-RNA1_PL1_org_210428"
+        plate1 = self.create_container(name1, False)
+        plate2 = self.create_container(name2, False)
+        platelist = sorted([plate2, plate1], key=SortStrategy.container_sort_key)
+        self.assertEqual("27-8473", platelist[0].name)
+        self.assertEqual("Test-RNA1_PL1_org_210428", platelist[1].name)
+
+
+class Dummy:
+    pass


### PR DESCRIPTION
Purpose:
Fix a bug related to plate sorting in python 3

Background:
Previously, a sort key has been generated for each plate according to
ab1_plate3_210505 --> (\<container sort weight\>, \<is temp plate\>, 'ab', 1, 'plate', 3, 210505)

This approach do not longer work in python3, becaus (probably) there is control tubes in the list behind the scene, with name = lims-id.

sort key for blank control:
24-12345 --> (\<container sort weight\>, \<is temp plate\>, 24, 12345)

which will cause comparison between int and str. 

Solution:
The sort key has fixed places for ints and strings, where string are on even indexes and int is on odd indexes. 
ab1_plate_210505 --> (\<container sort weight\>, \<is temp plate\>, 'ab', 1, 'plate', 0, '', 210505)
24-12345 --> (\<container sort weight\>, \<is temp plate\>, '', 24, '', 12345)

note the "0" and the '', when there is no number or is no string for the current name part. 
