### PR TITLE
WIP: dev 1331, add sample repo 

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -1,4 +1,7 @@
 from datetime import datetime
+
+from clarity_ext.inversion_of_control.ioc import ioc
+from clarity_ext.service.application import ApplicationService
 from clarity_ext.service.dilution.service import DilutionService
 from clarity_ext import UnitConversion
 from clarity_ext.repository import ClarityRepository, FileRepository
@@ -74,6 +77,7 @@ class ExtensionContext(object):
         use the constructor for custom use and unit tests.
         """
         session = ClaritySession.create(step_id)
+        ioc.set_application(ApplicationService(session))
         clarity_mapper = ClarityMapper()
         step_repo = StepRepository(session, clarity_mapper)
         artifact_service = ArtifactService(step_repo)

--- a/clarity_ext/domain/aliquot.py
+++ b/clarity_ext/domain/aliquot.py
@@ -1,5 +1,6 @@
 from clarity_ext.domain.artifact import Artifact
 from clarity_ext.domain.udf import DomainObjectWithUdf
+from clarity_ext.inversion_of_control.ioc import ioc
 
 
 class Aliquot(Artifact):
@@ -15,7 +16,7 @@ class Aliquot(Artifact):
     QC_FLAG_UNKNOWN = 'UNKNOWN'
 
     def __init__(self, api_resource, is_input, id=None, samples=None, name=None,
-                 well=None, qc_flag=None, udf_map=None, mapper=None, sample_repo=None):
+                 well=None, qc_flag=None, udf_map=None, mapper=None):
         super(Aliquot, self).__init__(api_resource=api_resource,
                                       artifact_id=id,
                                       name=name,
@@ -31,14 +32,13 @@ class Aliquot(Artifact):
             self.container = None
         self.is_from_original = False
         self.qc_flag = qc_flag if qc_flag else self.QC_FLAG_UNKNOWN
-        self._sample_repo = sample_repo
         self._samples = None
         self._sample_resources = samples or list()
         self._init_samples()
 
     def _init_samples(self):
         for sample_resource in self._sample_resources:
-            self._sample_repo.add_candidate(sample_resource)
+            ioc.app.sample_repository.add_candidate(sample_resource)
 
     @property
     def passed(self):
@@ -53,7 +53,7 @@ class Aliquot(Artifact):
     @property
     def samples(self):
         if self._samples is None:
-            self._samples = self._sample_repo.get_samples(self._sample_resources)
+            self._samples = ioc.app.sample_repository.get_samples(self._sample_resources)
         return self._samples
 
     @property

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -1,7 +1,6 @@
-from clarity_ext.domain.aliquot import Aliquot, Sample
+from clarity_ext.domain.aliquot import Aliquot
 from clarity_ext.domain.artifact import Artifact
 from clarity_ext import utils
-from clarity_ext.domain.udf import UdfMapping
 
 
 class Analyte(Aliquot):
@@ -23,7 +22,8 @@ class Analyte(Aliquot):
                  is_control=False,
                  udf_map=None,
                  is_from_original=None,
-                 mapper=None):
+                 mapper=None,
+                 sample_repo=None):
         """
         Creates an analyte
         """
@@ -35,7 +35,8 @@ class Analyte(Aliquot):
                                              well=well,
                                              qc_flag=qc_flag,
                                              udf_map=udf_map,
-                                             mapper=mapper)
+                                             mapper=mapper,
+                                             sample_repo=sample_repo)
         self.is_control = is_control
         self.is_output_from_previous = is_from_original
         self.reagent_labels = None

--- a/clarity_ext/domain/analyte.py
+++ b/clarity_ext/domain/analyte.py
@@ -22,8 +22,7 @@ class Analyte(Aliquot):
                  is_control=False,
                  udf_map=None,
                  is_from_original=None,
-                 mapper=None,
-                 sample_repo=None):
+                 mapper=None):
         """
         Creates an analyte
         """
@@ -35,8 +34,7 @@ class Analyte(Aliquot):
                                              well=well,
                                              qc_flag=qc_flag,
                                              udf_map=udf_map,
-                                             mapper=mapper,
-                                             sample_repo=sample_repo)
+                                             mapper=mapper)
         self.is_control = is_control
         self.is_output_from_previous = is_from_original
         self.reagent_labels = None

--- a/clarity_ext/domain/container.py
+++ b/clarity_ext/domain/container.py
@@ -209,6 +209,19 @@ class Container(DomainObjectWithUdf):
         for index in range(1, self.size.width + 1):
             yield index
 
+    @property
+    def samples(self):
+        """
+        List an unique set of samples in a container. Note that the same control sample
+        may occur in different pools, are here filtered.
+        :return:
+        """
+        analytes = [well.artifact for well in self.occupied]
+        sample_dict = {s.id: s for a in analytes for s in a.samples}
+        samples = [v for _, v in sample_dict.items()]
+        return samples
+
+
     @staticmethod
     def create_from_container(container):
         """Creates a container with the same dimensions as the other container"""
@@ -217,7 +230,7 @@ class Container(DomainObjectWithUdf):
                          is_source=container.is_source)
 
     @classmethod
-    def create_from_rest_resource(cls, resource, api_artifacts=[], is_source=None):
+    def create_from_rest_resource(cls, resource, api_artifacts=None, is_source=None):
         """
         Creates a container based on a resource from the REST API.
         """
@@ -230,8 +243,11 @@ class Container(DomainObjectWithUdf):
         ret.name = resource.name
         ret.size = size
 
+        if api_artifacts is None:
+            api_artifacts = []
         for artifact in api_artifacts:
-            ret.set_well_update_artifact(artifact.location[1], artifact)
+            well_position = artifact.location[1]
+            ret.set_well_update_artifact(well_position, artifact)
         ret.api_resource = resource
         return ret
 

--- a/clarity_ext/domain/udf.py
+++ b/clarity_ext/domain/udf.py
@@ -162,6 +162,12 @@ class UdfMapping(object):
     def clarity_udf_names(self):
         return [k for k in self.to_dict()]
 
+    def to_pythonic_dict(self):
+        # Returns a dict of the key/values where the key is pythonic version of the Clarity udf name.
+        # e.g. "udf_application", instead of "Application"
+        keys = [key for key in self.raw_map if key.startswith('udf_')]
+        return {key: self[key].value for key in keys}
+
     def __getitem__(self, key):
         return self.unwrap(key)
 

--- a/clarity_ext/inversion_of_control/ioc.py
+++ b/clarity_ext/inversion_of_control/ioc.py
@@ -1,0 +1,17 @@
+class InversionOfControl(object):
+    def __init__(self):
+        self._app = None
+
+    def set_application(self, app):
+        self._app = app
+
+    @property
+    def app(self):
+        if self._app is None:
+            raise ValueError(
+                'Inversion of control is not initialized. '
+                '(It needs to be initialized with an application service)')
+        return self._app
+
+
+ioc = InversionOfControl()

--- a/clarity_ext/mappers/clarity_mapper.py
+++ b/clarity_ext/mappers/clarity_mapper.py
@@ -47,6 +47,8 @@ class ClarityMapper(object):
         return self.map[domain_object]
 
     def sample_create_object(self, resource):
+        # from clarity_ext.utils import pretty_print
+        # pretty_print(resource)
         project = Project(resource.project.name) if resource.project else None
         udf_map = UdfMapping(resource.udf)
         sample = Sample(resource.id,
@@ -107,9 +109,7 @@ class ClarityMapper(object):
             udfs = resource.udf
 
         udf_map = UdfMapping(udfs)
-
         well = self.well_create_object(resource, container_repo, is_input)
-
         is_control = self._is_control(resource)
         # TODO: A better way to decide if analyte is output of a previous step?
         is_from_original = (resource.id.find("2-") != 0)

--- a/clarity_ext/mappers/clarity_mapper.py
+++ b/clarity_ext/mappers/clarity_mapper.py
@@ -82,7 +82,7 @@ class ClarityMapper(object):
                 resource.udf[udf_info.key] = udf_info.value
             return resource
 
-    def analyte_create_object(self, resource, is_input, container_repo, process_type):
+    def analyte_create_object(self, resource, is_input, container_repo, process_type, sample_repo):
         """
         Creates an Analyte from the rest resource. By default, the container
         is created from the related container resource, except if one
@@ -123,7 +123,8 @@ class ClarityMapper(object):
                           is_control=is_control,
                           udf_map=udf_map,
                           is_from_original=is_from_original,
-                          mapper=self)
+                          mapper=self,
+                          sample_repo=sample_repo)
         analyte.api_resource = resource
         self._after_object_created(analyte, resource)
         self.domain_map[resource.id] = analyte

--- a/clarity_ext/repository/container_repository.py
+++ b/clarity_ext/repository/container_repository.py
@@ -10,11 +10,15 @@ class ContainerRepository:
     def __init__(self):
         self.cache = dict()
 
-    def get_container(self, container_resource, is_source):
+    def get_container(self, container_resource, is_source, artifacts=None):
         # TODO: It looks silly to have is_input here
         if container_resource.id in self.cache:
             return self.cache[container_resource.id]
         else:
-            ret = Container.create_from_rest_resource(container_resource, is_source=is_source)
+            ret = Container.create_from_rest_resource(
+                container_resource,
+                api_artifacts=artifacts,
+                is_source=is_source,
+            )
             self.cache[container_resource.id] = ret
             return ret

--- a/clarity_ext/repository/sample_repository.py
+++ b/clarity_ext/repository/sample_repository.py
@@ -1,0 +1,38 @@
+from clarity_ext.mappers.clarity_mapper import ClarityMapper
+
+
+class SampleRepository(object):
+    """
+    During initiation of current context (i.e. at step repository at clarity-ext
+    or container repository at snpseq-data) fill up a list of candidates,
+    consisting of all (un-fetched) samples needed in the current context.
+    Upon first request of a sample (typically within script execution), fetch
+    them all in one swoop, by get_batch()
+    """
+    def __init__(self, session):
+        self.session = session
+        self.candidates = list()  # not-fetched genologics sample resources
+        self.samples = dict()
+        self._is_fetched = False
+
+    def add_candidate(self, sample_resource):
+        self.candidates.append(sample_resource)
+
+    def get_samples(self, sample_resources):
+        if not self._is_fetched:
+            self._fetch_candidates()
+            self._is_fetched = True
+        try:
+            samples = [self.samples[s.uri] for s in sample_resources]
+        except KeyError:
+            raise AssertionError("All samples are not present in sample cache. "
+                                 "Is SampleRepository initialized the right way?")
+        return samples
+
+    def _fetch_candidates(self):
+        fetched_resources = self.session.api.get_batch(self.candidates)
+        mapper = ClarityMapper()
+        for resource in fetched_resources:
+            sample = mapper.sample_create_object(resource)
+            self.samples[resource.uri] = sample
+

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -128,7 +128,6 @@ class StepRepository(object):
             input_resource,
             output_resource,
             output_generation_type,
-            container_repo,
             process_type):
         # Create a map of all containers, so we can fill in it while building
         # domain objects.
@@ -138,14 +137,12 @@ class StepRepository(object):
 
         input = self._wrap_artifact(
             input_resource,
-            container_repo,
             gen_type="Input",
             is_input=True,
             process_type=process_type)
 
         output = self._wrap_artifact(
             output_resource,
-            container_repo,
             gen_type=output_generation_type,
             is_input=False,
             process_type=process_type)
@@ -169,7 +166,7 @@ class StepRepository(object):
 
         return input, output
 
-    def _wrap_artifact(self, artifact, container_repo, gen_type, is_input, process_type):
+    def _wrap_artifact(self, artifact, gen_type, is_input, process_type):
         """
         Wraps an artifact in a domain object, if one exists. The domain objects provide logic
         convenient methods for working with the domain object in extensions.
@@ -177,10 +174,10 @@ class StepRepository(object):
 
         if artifact.type == "Analyte":
             wrapped = self.clarity_mapper.analyte_create_object(
-                artifact, is_input, container_repo, process_type)
+                artifact, is_input, process_type)
         elif artifact.type == "ResultFile" and gen_type == "PerInput":
             wrapped = self.clarity_mapper.result_file_create_object(
-                artifact, is_input, container_repo, process_type)
+                artifact, is_input, process_type)
         elif artifact.type == "ResultFile" and gen_type == "PerAllInputs":
             wrapped = SharedResultFile.create_from_rest_resource(
                 artifact, process_type)

--- a/clarity_ext/repository/step_repository.py
+++ b/clarity_ext/repository/step_repository.py
@@ -116,7 +116,6 @@ class StepRepository(object):
                     input_resource,
                     output_resource,
                     output_gen_type,
-                    container_repo,
                     process_type)
             if output_domain_obj.id in outputs_by_id:
                 output_domain_obj = outputs_by_id[output_domain_obj.id]
@@ -124,11 +123,9 @@ class StepRepository(object):
             outputs_by_id[output_domain_obj.id] = output_domain_obj
         return ret
 
-    def _wrap_input_output(self,
-            input_resource,
-            output_resource,
-            output_generation_type,
-            process_type):
+    def _wrap_input_output(
+            self, input_resource, output_resource,
+            output_generation_type,process_type):
         # Create a map of all containers, so we can fill in it while building
         # domain objects.
 

--- a/clarity_ext/service/application.py
+++ b/clarity_ext/service/application.py
@@ -1,0 +1,12 @@
+from clarity_ext.repository.sample_repository import SampleRepository
+from clarity_ext.repository.container_repository import ContainerRepository
+
+
+class ApplicationService(object):
+    """
+    Sets up instances of all required repositories in the system.
+    """
+
+    def __init__(self, session):
+        self.sample_repository = SampleRepository(session)
+        self.container_repository = ContainerRepository()

--- a/clarity_ext/utils.py
+++ b/clarity_ext/utils.py
@@ -5,6 +5,8 @@ import hashlib
 import logging
 from contextlib import contextmanager
 import types
+import xml.etree.ElementTree as ET
+import xml.dom.minidom
 
 
 # http://stackoverflow.com/a/3013910/282024
@@ -131,6 +133,18 @@ def get_jinja_template_from_package(package, name):
     for candidate_file in os.listdir(templates_dir):
         if candidate_file == name:
             return os.path.join(templates_dir, candidate_file)
+
+
+def pretty_print(api_resource):
+    """
+    Used for pretty print genologics api resources when debugging.
+    Prints indented xml.
+    """
+    xml_string = ET.tostring(api_resource.root, encoding='unicode')
+    dom = xml.dom.minidom.parseString(xml_string)
+    pretty_xml_as_string = dom.toprettyxml()
+    print(pretty_xml_as_string)
+
 
 class UnexpectedLengthError(ValueError):
     pass

--- a/test/unit/clarity_ext/domain/test_artifact.py
+++ b/test/unit/clarity_ext/domain/test_artifact.py
@@ -1,4 +1,9 @@
 import unittest
+
+from clarity_ext import ClaritySession
+from clarity_ext.inversion_of_control.ioc import ioc
+from clarity_ext.service.application import ApplicationService
+from genologics.lims import Lims
 from test.unit.clarity_ext.helpers import fake_analyte, fake_result_file
 from test.unit.clarity_ext.helpers import fake_shared_result_file
 from test.unit.clarity_ext.helpers import fake_container
@@ -13,6 +18,9 @@ from clarity_ext.mappers.clarity_mapper import ClarityMapper
 
 
 class TestArtifact(unittest.TestCase):
+    def setUp(self):
+        ioc.set_application(ApplicationService(None))
+
     def test_two_identical_artifacts_equal(self):
         """A copy of an artifact should be equal to another"""
         artifacts = [ResultFile(api_resource=None, is_input=False),
@@ -77,10 +85,11 @@ class TestArtifact(unittest.TestCase):
         container_repo = MagicMock()
         container = fake_container("cont1")
         container_repo.get_container.return_value = container
+        ioc.app.container_repository = container_repo
 
         clarity_mapper = ClarityMapper()
         analyte = clarity_mapper.analyte_create_object(
-            api_resource, is_input=True, container_repo=container_repo, process_type=MagicMock())
+            api_resource, is_input=True, process_type=MagicMock())
 
         expected_analyte = fake_analyte(container_id="cont1", artifact_id="art1", sample_ids=["sample1"],
                                         analyte_name="sample1", well_key="B:2", is_input=True,
@@ -111,10 +120,11 @@ class TestArtifact(unittest.TestCase):
             resouce_id="art1", sample_name="sample1", well_position="B:2")
         api_resource.udf = {}
         container_repo = mock_container_repo(container_id="cont1")
+        ioc.app.container_repository = container_repo
 
         clarity_mapper = ClarityMapper()
         result_file = clarity_mapper.result_file_create_object(
-            api_resource, is_input=False, container_repo=container_repo,
+            api_resource, is_input=False,
             process_type=self._create_process_type_mock(field_definitions=[]))
 
         expected_result_file = fake_result_file(
@@ -131,12 +141,11 @@ class TestArtifact(unittest.TestCase):
         api_resource = mock_artifact_resource(
             resouce_id="art1", sample_name="sample1")
         api_resource.udf = udfs
-        container_repo = mock_container_repo(container_id=None)
 
         clarity_mapper = ClarityMapper()
         result_file = clarity_mapper.result_file_create_object(
             api_resource, is_input=False,
-            container_repo=container_repo, process_type=self._create_process_type_mock(field_definitions=["UDF1"]))
+            process_type=self._create_process_type_mock(field_definitions=["UDF1"]))
 
         expected_result_file = fake_result_file(
             artifact_id="art1", container_id=None, name="sample1", well_key="B:2",

--- a/test/unit/clarity_ext/service/test_sample_repository.py
+++ b/test/unit/clarity_ext/service/test_sample_repository.py
@@ -1,0 +1,23 @@
+import unittest
+from clarity_ext.inversion_of_control.ioc import ioc
+from clarity_ext.repository.sample_repository import SampleRepository
+from clarity_ext.service.application import ApplicationService
+from genologics.entities import Container, Artifact, Sample
+from genologics.lims import Lims
+
+
+class TestSampleRepository(unittest.TestCase):
+    def test_fetch_sample_not_initialized__assert_exception_thrown(self):
+        lims = Lims('', '', '')
+        session = FakeSession(lims)
+        sample_repo = SampleRepository(session)
+        sample_resource = Sample(lims, uri='someting')
+        self.assertRaises(
+            AssertionError, lambda: sample_repo.get_samples([sample_resource])
+        )
+
+
+class FakeSession(object):
+    def __init__(self, lims):
+        self.api = lims
+        ioc.set_application(ApplicationService(self))


### PR DESCRIPTION
This is WIP because it should not be included into the current release (2021-05-28)

Purpose:
Adjust clarity-ext so that one can fetch related data (i.e. samples) from container name as the primary search key. This is to be used by the snpseq-data repository

Implementation:
Add a sample respository. This is initalized during setup with all samples to be fetched from the current context, which can be either a step or a container. At first call to get_samples(), all samples are fetched at one swoop.

In addition, I also implemented an inversion of control instance, in order to avoid sending in each and every repository as input argument to domain classes during initialization. 