### PR TITLE
lims-2324, Bugfix: Detect file encoding prior to opening them

### DIFF
--- a/clarity_ext/repository/file_repository.py
+++ b/clarity_ext/repository/file_repository.py
@@ -1,3 +1,6 @@
+from bs4 import UnicodeDammit
+
+
 class FileRepository:
     """
     Handles remote and local file access.
@@ -22,4 +25,10 @@ class FileRepository:
         Provided for being able to test with dependency injection instead of patching open.
         Services will always use this way of opening files.
         """
-        return open(local_path, mode)
+        with open(local_path, 'rb') as f:
+            byte_contents = f.read()
+
+        dammit = UnicodeDammit(byte_contents, ['uft-8', 'latin-1'])
+        if not dammit.original_encoding or not dammit.unicode_markup:
+            raise UnicodeError("Failed to detect encoding for this file.")
+        return open(local_path, mode, encoding=dammit.original_encoding)


### PR DESCRIPTION
This is a bug that currently stops the production. 
Should it be sent directly to next, or should it be tested in dev first?

The bug:
Some files containing special characters generates runtime error at script execution. In python2, these files were read without notice. The root cause for this is that clarity-ext uses the default encoding utf-8, while in these cases the files are encoded with latin-1.

Solution:
Prior reading contents of a file into unicode, the encoding of the file is first assessed by reading the byte contents and then let   UnicodeDammit() try to detect the encoding from it. 