### PR TITLE
lims-2324, Handle encoding for empty files

### DIFF
--- a/clarity_ext/repository/file_repository.py
+++ b/clarity_ext/repository/file_repository.py
@@ -28,9 +28,9 @@ class FileRepository:
         with open(local_path, 'rb') as f:
             byte_contents = f.read()
 
-        dammit = UnicodeDammit(byte_contents, ['uft-8', 'latin-1'])
+        dammit = UnicodeDammit(byte_contents, ['utf-8', 'latin-1'])
         if len(byte_contents) > 0 and \
                 (not dammit.original_encoding or not dammit.unicode_markup):
             raise UnicodeError("Failed to detect encoding for this file.")
-        encoding = dammit.unicode_markup or 'utf-8'
+        encoding = dammit.original_encoding or 'utf-8'
         return open(local_path, mode, encoding=encoding)

--- a/clarity_ext/repository/file_repository.py
+++ b/clarity_ext/repository/file_repository.py
@@ -29,6 +29,8 @@ class FileRepository:
             byte_contents = f.read()
 
         dammit = UnicodeDammit(byte_contents, ['uft-8', 'latin-1'])
-        if not dammit.original_encoding or not dammit.unicode_markup:
+        if len(byte_contents) > 0 and \
+                (not dammit.original_encoding or not dammit.unicode_markup):
             raise UnicodeError("Failed to detect encoding for this file.")
-        return open(local_path, mode, encoding=dammit.original_encoding)
+        encoding = dammit.unicode_markup or 'utf-8'
+        return open(local_path, mode, encoding=encoding)


### PR DESCRIPTION
This is a followup bugfix. Handle empty files when asserting which encoding a file has. This happens for the empty step logs when entering a step. 