### PR TITLE
Templates should use the newline function from the base class

### DIFF
--- a/clarity_ext/extensions.py
+++ b/clarity_ext/extensions.py
@@ -772,9 +772,7 @@ class TemplateExtension(DriverFileExtension, metaclass=ABCMeta):
     def content(self):
         with open(self.template_path, 'r') as fs:
             text = fs.read()
-            windows_eol = '\r\n'
-            newline_sequence = windows_eol if windows_eol in text else '\n'
-            template = Template(text, newline_sequence=newline_sequence)
+            template = Template(text, newline_sequence=self.newline())
             rendered = template.render(ext=self)
             return rendered
 


### PR DESCRIPTION
After moving to Py3 line endings are automatically changed to
'\n', even if they use '\r\n'. So Windows line endings where
being removed.

This solution requires the user to specify what line ending is used
rather than using the one that's in the template file.