### PR TITLE
dev-1466, Fix printing out exceptions the python 3 way

### DIFF
--- a/clarity_ext/cli.py
+++ b/clarity_ext/cli.py
@@ -121,7 +121,7 @@ def extension(module, mode, args, cache):
             try:
                 extension_svc.run_test(config, args, module, True, cache, validate_against_frozen)
             except ResultsDifferFromFrozenData as ex:
-                print("Results differ from frozen data: " + ex.message)
+                print("Results differ from frozen data: " + str(ex))
         elif mode == ExtensionService.RUN_MODE_EXEC:
             extension_svc.set_log_strategy(log_level, False, True, True, "/opt/clarity-ext/logs", "extensions.log")
             extension_svc.run_exec(config, args, module)
@@ -132,7 +132,7 @@ def extension(module, mode, args, cache):
             # Just re-raise when testing - to keep the stacktrace
             raise
         logger.exception("Exception while running extension")
-        msg = "There was an exception while running the extension: '{}'. ".format(ex.message) + \
+        msg = "There was an exception while running the extension: '{}'. ".format(ex) + \
               "Refer to the file 'Step log' if available."
         if extension_svc.rotating_file_path:
             msg += " The application log is available in {}.".format(extension_svc.rotating_file_path)

--- a/clarity_ext/data_cli.py
+++ b/clarity_ext/data_cli.py
@@ -83,7 +83,7 @@ def get_stages(workflow_status, workflow_name, protocol_name, stage_name, use_ca
             try:
                 print("\t".join([stage.workflow.name, stage.protocol.name, stage.name, stage.uri]))
             except AttributeError as e:
-                print("# ERROR workflow={}: {}".format(workflow.uri, e.message))
+                print("# ERROR workflow={}: {}".format(workflow.uri, e))
 
 
 @main.command("move-artifacts-plan")

--- a/clarity_ext/integration.py
+++ b/clarity_ext/integration.py
@@ -102,7 +102,7 @@ class IntegrationTestService(object):
             except Exception as e:
                 # It's OK to use a catch-all exception handler here since this is only used while
                 # running tests, so we want to be optimistic and try to run all tests:
-                print("- {}: ERROR - {}".format(module, e.message))
+                print("- {}: ERROR - {}".format(module, e))
                 print("  Fresh run:    clarity-ext extension {} test-fresh".format(module))
                 print("  Review, then: clarity-ext extension {} freeze".format(module))
                 exception_count += 1


### PR DESCRIPTION
The "message" attribute is removed from exceptions in python 3. Adjust code for that. 

These changes affects (only ?) how errors are presented in UI. 