### PR TITLE
Dilution slow

### DIFF
--- a/clarity_ext/domain/aliquot.py
+++ b/clarity_ext/domain/aliquot.py
@@ -1,5 +1,5 @@
 from clarity_ext.domain.artifact import Artifact
-from clarity_ext.domain.udf import DomainObjectWithUdfMixin
+from clarity_ext.domain.udf import DomainObjectWithUdf
 
 
 class Aliquot(Artifact):
@@ -67,7 +67,7 @@ class Aliquot(Artifact):
         return len(self._samples) > 1
 
 
-class Sample(DomainObjectWithUdfMixin):
+class Sample(DomainObjectWithUdf):
 
     def __init__(self, sample_id, name, project, udf_map=None, mapper=None):
         """
@@ -87,6 +87,6 @@ class Sample(DomainObjectWithUdfMixin):
         return "<Sample id={}>".format(self.id)
 
 
-class Project(DomainObjectWithUdfMixin):
+class Project(DomainObjectWithUdf):
     def __init__(self, name):
         self.name = name

--- a/clarity_ext/domain/aliquot.py
+++ b/clarity_ext/domain/aliquot.py
@@ -77,8 +77,7 @@ class Sample(DomainObjectWithUdf):
         :param udf_map: An UdfMapping
         :param mapper: The ClarityMapper
         """
-        super(Sample, self).__init__(udf_map=udf_map)
-        self.id = sample_id
+        super(Sample, self).__init__(udf_map=udf_map, id=sample_id)
         self.name = name
         self.project = project
         self._mapper = mapper

--- a/clarity_ext/domain/artifact.py
+++ b/clarity_ext/domain/artifact.py
@@ -1,8 +1,7 @@
-from clarity_ext.domain.udf import DomainObjectWithUdfMixin
-from clarity_ext.domain.common import DomainObjectMixin
+from clarity_ext.domain.udf import DomainObjectWithUdf
 
 
-class Artifact(DomainObjectWithUdfMixin):
+class Artifact(DomainObjectWithUdf):
     """
     Represents any input or output artifact from the Clarity server, e.g. an Analyte
     or a ResultFile.

--- a/clarity_ext/domain/common.py
+++ b/clarity_ext/domain/common.py
@@ -10,29 +10,6 @@ class DomainObjectMixin(object):
         else:
             return False
 
-    def __hash__(self):
-        return hash(self.id)
-
-    def __lt__(self, other):
-        return self.compare(other) < 0
-
-    def __gt__(self, other):
-        return self.compare(other) > 0
-
-    def __le__(self, other):
-        return self.compare(other) <= 0
-
-    def __ge__(self, other):
-        return self.compare(other) >= 0
-
-    def compare(self, other):
-        # Override if needed
-        if self._eq_rec(self, other) == 0:
-            return 0
-        elif str(self) < str(other):
-            return -1
-        return 1
-
     def _eq_rec(self, a, b, cache=[]):
         """
         Replaces the == operator because of circulating references (e.g. analyte <-> well)

--- a/clarity_ext/domain/common.py
+++ b/clarity_ext/domain/common.py
@@ -3,12 +3,17 @@ import copy
 
 
 class DomainObject(object):
+    def __init__(self, id):
+        self.id = id
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
             return self._eq_rec(self, other)
         else:
             return False
+
+    def __lt__(self, other):
+        return self.id < other.id
 
     def _eq_rec(self, a, b, cache=[]):
         """

--- a/clarity_ext/domain/common.py
+++ b/clarity_ext/domain/common.py
@@ -2,7 +2,7 @@ from builtins import isinstance
 import copy
 
 
-class DomainObjectMixin(object):
+class DomainObject(object):
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -17,9 +17,9 @@ class DomainObjectMixin(object):
         http://stackoverflow.com/questions/31415844/using-the-operator-on-circularly-defined-dictionaries
         """
         cache = cache + [a, b]
-        if isinstance(a, DomainObjectMixin):
+        if isinstance(a, DomainObject):
             a = a.__dict__
-        if isinstance(b, DomainObjectMixin):
+        if isinstance(b, DomainObject):
             b = b.__dict__
         if not isinstance(a, dict) or not isinstance(b, dict):
             return a == b
@@ -55,7 +55,7 @@ class DomainObjectMixin(object):
             return None
 
 
-class AssignLogger(DomainObjectMixin):
+class AssignLogger(DomainObject):
     def __init__(self, domain_object_mixin):
         self.log = []
         self.domain_object_mixin = domain_object_mixin

--- a/clarity_ext/domain/container.py
+++ b/clarity_ext/domain/container.py
@@ -1,11 +1,11 @@
 from collections import namedtuple
 from clarity_ext.utils import lazyprop
-from clarity_ext.domain.common import DomainObjectMixin
-from clarity_ext.domain.udf import DomainObjectWithUdfMixin
+from clarity_ext.domain.common import DomainObject
+from clarity_ext.domain.udf import DomainObjectWithUdf
 from clarity_ext.domain.udf import UdfMapping
 
 
-class Well(DomainObjectMixin):
+class Well(DomainObject):
     """
     Encapsulates a location in a container.
 
@@ -108,7 +108,7 @@ class PlateSize(namedtuple("PlateSize", ["height", "width"])):
     pass
 
 
-class Container(DomainObjectWithUdfMixin):
+class Container(DomainObjectWithUdf):
     """Encapsulates a Container"""
 
     DOWN_FIRST = 1

--- a/clarity_ext/domain/container.py
+++ b/clarity_ext/domain/container.py
@@ -127,11 +127,10 @@ class Container(DomainObjectWithUdf):
         :param container_type: The type of the container (string)
         :return:
         """
-        self.udf_map = udf_map
+        super().__init__(udf_map=udf_map, id=container_id)
         self.mapping = mapping
         # TODO: using both container_type and container_type_name is temporary
         self.container_type = container_type
-        self.id = container_id
         self.name = name
 
         # Set to True if the plate represents no actual plate in Clarity

--- a/clarity_ext/domain/process.py
+++ b/clarity_ext/domain/process.py
@@ -1,7 +1,7 @@
-from clarity_ext.domain.udf import DomainObjectWithUdfMixin, UdfMapping
+from clarity_ext.domain.udf import DomainObjectWithUdf, UdfMapping
 
 
-class Process(DomainObjectWithUdfMixin):
+class Process(DomainObjectWithUdf):
     """Represents a Process (step)"""
 
     def __init__(self, api_resource, process_id, technician, udf_map, ui_link, instrument=None):

--- a/clarity_ext/domain/udf.py
+++ b/clarity_ext/domain/udf.py
@@ -9,13 +9,14 @@ logger = logging.getLogger(__name__)
 # map (since we're not adding the udfs to the object, or add them to the object)
 class DomainObjectWithUdf(DomainObject):
     def __init__(self, api_resource=None, id=None, udf_map=None):
+        super().__init__(id)
+
         # NOTE: The udf_map must be the first object set,
         # since it's used in __getattr__ and __setattr__
         if udf_map is None:
             udf_map = UdfMapping()
         self.udf_map = udf_map
         self.api_resource = api_resource
-        self.id = id
 
     def __getattr__(self, key):
         """Getter that supports access to the extra udf_ attributes"""

--- a/clarity_ext/domain/udf.py
+++ b/clarity_ext/domain/udf.py
@@ -41,6 +41,9 @@ class DomainObjectWithUdfMixin(DomainObjectMixin):
         else:
             super(DomainObjectWithUdfMixin, self).__setattr__(key, value)
 
+    def __hash__(self):
+        return hash(self.id)
+
     def _create_udf_exception(self, key):
         return AttributeError("The udf '{}' does not exist in the udf_map. Available values are: '{}'"
                               .format(key, self.udf_map.usage()))

--- a/clarity_ext/domain/udf.py
+++ b/clarity_ext/domain/udf.py
@@ -207,7 +207,7 @@ class UdfMapping(object):
         """
         new_name = original_udf_name.lower().replace(" ", "_")
         # Get rid of all non-alphanumeric characters
-        new_name = re.sub("\W+", "", new_name)
+        new_name = re.sub(r"\W+", "", new_name)
         new_name = "udf_{}".format(new_name)
         # Now ensure that we don't have repeated undercores:
         new_name = re.sub("_{2,}", "_", new_name)

--- a/clarity_ext/domain/udf.py
+++ b/clarity_ext/domain/udf.py
@@ -1,5 +1,5 @@
 import re
-from clarity_ext.domain.common import DomainObjectMixin
+from clarity_ext.domain.common import DomainObject
 import logging
 
 logger = logging.getLogger(__name__)
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 # TODO: Ensure that this overrides the equality check too, to take into account the UDF
 # map (since we're not adding the udfs to the object, or add them to the object)
-class DomainObjectWithUdfMixin(DomainObjectMixin):
+class DomainObjectWithUdf(DomainObject):
     def __init__(self, api_resource=None, id=None, udf_map=None):
         # NOTE: The udf_map must be the first object set,
         # since it's used in __getattr__ and __setattr__
@@ -39,7 +39,7 @@ class DomainObjectWithUdfMixin(DomainObjectMixin):
             else:
                 raise self._create_udf_exception(key)
         else:
-            super(DomainObjectWithUdfMixin, self).__setattr__(key, value)
+            super(DomainObjectWithUdf, self).__setattr__(key, value)
 
     def __hash__(self):
         return hash(self.id)

--- a/clarity_ext/service/dilution/service.py
+++ b/clarity_ext/service/dilution/service.py
@@ -4,11 +4,11 @@ import logging
 import re
 from itertools import groupby
 from itertools import chain
-import collections
+import collections.abc
 from collections import namedtuple
 from abc import abstractmethod
 from clarity_ext.service.file_service import Csv
-from clarity_ext.domain.validation import ValidationException, ValidationType, ValidationResults, UsageError
+from clarity_ext.domain.validation import ValidationException, ValidationType, ValidationResults
 from clarity_ext import utils
 from clarity_ext.domain import Container, Well
 from clarity_ext.domain.container import PlateSize
@@ -84,7 +84,7 @@ class DilutionSession(object):
         """
         transfer_handlers = list()
         for transfer_handler_type in transfer_handler_types:
-            if isinstance(transfer_handler_type, collections.Iterable):
+            if isinstance(transfer_handler_type, collections.abc.Iterable):
                 initialized = [t(self, dilution_settings, robot_settings, virtual_batch)
                                for t in transfer_handler_type]
                 transfer_handlers.append(OrTransferHandler(self, dilution_settings, robot_settings,
@@ -630,11 +630,11 @@ class SortStrategy:
         name_parts = re.split('[-_]+', container_name)
         name_sort_array = list()
         for part in name_parts:
-            strings = re.split('\d+', part)
+            strings = re.split(r'\d+', part)
             strings = [s for s in strings if s != '']
             strings = [x.lower() for x in strings]
 
-            numbers = re.split('\D+', part)
+            numbers = re.split(r'\D+', part)
             numbers = [n for n in numbers if n != '']
             numbers = [int(x) for x in numbers]
 

--- a/clarity_ext/utility/testing.py
+++ b/clarity_ext/utility/testing.py
@@ -223,7 +223,7 @@ class TestExtensionContext(object):
         self._analytes.extend((pair.input_artifact, pair.output_artifact) for pair in pairs)
 
 
-class TestExtensionWrapper(object):
+class ExtensionWrapperForTests(object):
     """Similar to TestExtensionContext, but wraps an entire extension"""
 
     def __init__(self, extension_type):


### PR DESCRIPTION
A few changes related to the slowness of the dilution scripts.

The main change is that we now compare objects simply by `id` and only by supporting the `__lt__` method.

There are other changes that are related to pytest warnings and `DomainObjectMixin` and `DomainObjectWithUdfMixin` are renamed so they don't have `Mixin` in their name. This is because they are only ever used as base classes.

The auth monkey patch is being removed from the frozen tests feature as we don't use it anymore and some tests were failing because of it.