### PR TITLE
Fix a bug that happens at step commit

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -77,8 +77,8 @@ class ExtensionContext(object):
         use the constructor for custom use and unit tests.
         """
         session = ClaritySession.create(step_id)
-        ioc.set_application(ApplicationService(session))
         clarity_mapper = ClarityMapper()
+        ioc.set_application(ApplicationService(session, clarity_mapper))
         step_repo = StepRepository(session, clarity_mapper)
         artifact_service = ArtifactService(step_repo)
         current_user = step_repo.current_user()

--- a/clarity_ext/repository/sample_repository.py
+++ b/clarity_ext/repository/sample_repository.py
@@ -9,8 +9,9 @@ class SampleRepository(object):
     Upon first request of a sample (typically within script execution), fetch
     them all in one swoop, by get_batch()
     """
-    def __init__(self, session):
+    def __init__(self, session, clarity_mapper):
         self.session = session
+        self.clarity_mapper = clarity_mapper
         self.candidates = list()  # not-fetched genologics sample resources
         self.samples = dict()
         self._is_fetched = False
@@ -31,8 +32,7 @@ class SampleRepository(object):
 
     def _fetch_candidates(self):
         fetched_resources = self.session.api.get_batch(self.candidates)
-        mapper = ClarityMapper()
         for resource in fetched_resources:
-            sample = mapper.sample_create_object(resource)
+            sample = self.clarity_mapper.sample_create_object(resource)
             self.samples[resource.uri] = sample
 

--- a/clarity_ext/service/application.py
+++ b/clarity_ext/service/application.py
@@ -7,6 +7,6 @@ class ApplicationService(object):
     Sets up instances of all required repositories in the system.
     """
 
-    def __init__(self, session):
-        self.sample_repository = SampleRepository(session)
+    def __init__(self, session, clarity_mapper):
+        self.sample_repository = SampleRepository(session, clarity_mapper)
         self.container_repository = ContainerRepository()

--- a/clarity_ext/utility/testing.py
+++ b/clarity_ext/utility/testing.py
@@ -187,7 +187,7 @@ class TestExtensionContext(object):
         # TODO: only mocking this one method of the validation_service for now (quick fix)
         self.context.validation_service.handle_single_validation = MagicMock()
         self.context.logger = MagicMock()
-        application = ApplicationService(session)
+        application = ApplicationService(session, None)
         ioc.set_application(application)
 
         self._shared_files = list()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 from clarity_ext import VERSION
 
 dependencies = ['click', 'genologics', 'requests-cache', 'pyyaml', 'nose', 'PyPDF2',
-                'lxml', 'coverage', 'pep8radius', 'mock', 'jinja2', 'python-levenshtein',
+                'lxml', 'coverage', 'pep8radius', 'mock', 'jinja2',
                 'fuzzywuzzy', 'pandas', 'xlrd', 'bs4']
 
 setup(

--- a/test/unit/clarity_ext/domain/test_artifact.py
+++ b/test/unit/clarity_ext/domain/test_artifact.py
@@ -19,7 +19,7 @@ from clarity_ext.mappers.clarity_mapper import ClarityMapper
 
 class TestArtifact(unittest.TestCase):
     def setUp(self):
-        ioc.set_application(ApplicationService(None))
+        ioc.set_application(ApplicationService(None, None))
 
     def test_two_identical_artifacts_equal(self):
         """A copy of an artifact should be equal to another"""

--- a/test/unit/clarity_ext/service/test_sample_repository.py
+++ b/test/unit/clarity_ext/service/test_sample_repository.py
@@ -10,7 +10,7 @@ class TestSampleRepository(unittest.TestCase):
     def test_fetch_sample_not_initialized__assert_exception_thrown(self):
         lims = Lims('', '', '')
         session = FakeSession(lims)
-        sample_repo = SampleRepository(session)
+        sample_repo = SampleRepository(session, None)
         sample_resource = Sample(lims, uri='someting')
         self.assertRaises(
             AssertionError, lambda: sample_repo.get_samples([sample_resource])
@@ -20,4 +20,4 @@ class TestSampleRepository(unittest.TestCase):
 class FakeSession(object):
     def __init__(self, lims):
         self.api = lims
-        ioc.set_application(ApplicationService(self))
+        ioc.set_application(ApplicationService(self, None))


### PR DESCRIPTION
Description:
The bug is related to the domain object instantiation process in clarity-ext. In clarity, analytes can be fetched at high speed, because they are included in the api response for the step. The related entity "sample" (think original sample), on the other side, takes long time to fetch. For a while ago, a feature was introduced, that fetched all samples in a step in one swoop. When the first sample was requested, instead of fetching one single sample, all samples were fetched for the current step. 

The proper instantiation goes like this:
1. fetch xml representation for an object (analyte or sample), instantiate a python domain object
2. Register this object in clarity_mapper, which contains a cache (evil?!) of all objects in the step
3. Script execution updates the domain object
4. Push up the updated domain object to API in commit method. Here, the object is sometimes once again fetched from the cache in clarity_mapper.

The bug here was that clarity_mapper was instanciated locally in sample_repository. It needs to be the very same instance that is used at domain instantiation (step 2 above), as in the commit action (step 4 above). 

Validation:
* All unit tests pass
* Integration test for qc.qc_commit.py runs without failure
