### PR TITLE
Remove old tweak code

### DIFF
--- a/clarity_ext/domain/aliquot.py
+++ b/clarity_ext/domain/aliquot.py
@@ -58,9 +58,6 @@ class Aliquot(Artifact):
 
     @property
     def is_pool(self):
-        if self._samples is None:
-            # TODO: Happens only in a test, fix that...
-            return False
         return len(self._sample_resources) > 1
 
 


### PR DESCRIPTION
There was a conditional statement in is_pool() method, Aliquot class, that was present only to
fix unit tests. Since the handling of samples were changed some time
ago, this is both unnecessary (the test pass anyway), and induce a bug.
So, remove this conditional statement fixes the whole issue.