### PR TITLE
2417 reagent repository validation

### DIFF
--- a/clarity_ext/domain/aliquot.py
+++ b/clarity_ext/domain/aliquot.py
@@ -1,6 +1,7 @@
 from clarity_ext.domain.artifact import Artifact
 from clarity_ext.domain.udf import DomainObjectWithUdf
 from clarity_ext.inversion_of_control.ioc import ioc
+from clarity_ext.utils import single
 
 
 class Aliquot(Artifact):
@@ -34,6 +35,7 @@ class Aliquot(Artifact):
         self.qc_flag = qc_flag if qc_flag else self.QC_FLAG_UNKNOWN
         self._samples = None
         self._sample_resources = samples or list()
+        self.reagent_label = single(api_resource.reagent_labels)
         self._init_samples()
 
     def _init_samples(self):

--- a/clarity_ext/domain/udf.py
+++ b/clarity_ext/domain/udf.py
@@ -85,6 +85,10 @@ class DomainObjectWithUdf(DomainObject):
 
         if self.qc_flag != self.api_resource.qc_flag:
             attrib_updates = True
+
+        if [self.reagent_label] != self.api_resource.reagent_labels:
+            attrib_updates = True
+
         if len(updated_fields) == 0 and not attrib_updates:
             return None
         else:
@@ -92,6 +96,7 @@ class DomainObjectWithUdf(DomainObject):
                 new_api_resource.udf[udf_info.key] = udf_info.value
             new_api_resource.name = self.name
             new_api_resource.qc_flag = self.qc_flag
+            new_api_resource.reagent_labels = [self.reagent_label]
             return new_api_resource
 
 

--- a/clarity_ext/repository/reagent_type_repository.py
+++ b/clarity_ext/repository/reagent_type_repository.py
@@ -17,7 +17,7 @@ class ReagentTypeRepository:
         return ret
 
     def get_reagent_type(self, label):
-        reagent_type = self.get_reagent_types(label=label))
+        reagent_type = self.get_reagent_types(label=label)
 
         if len(reagent_type) == 1:
             return single(reagent_type)

--- a/clarity_ext/repository/reagent_type_repository.py
+++ b/clarity_ext/repository/reagent_type_repository.py
@@ -17,5 +17,15 @@ class ReagentTypeRepository:
         return ret
 
     def get_reagent_type(self, label):
-        return single(self.get_reagent_types(label=label))
+        reagent_type = self.get_reagent_types(label=label))
+
+        if len(reagent_type) == 1:
+            return single(reagent_type)
+        elif len(reagent_type) == 0:
+            return None
+        else:
+            raise ValueError("'{}' is associated with more than one reagent type".format(label))
+
+
+
 


### PR DESCRIPTION
1. reagent_label attribute as been added to the aliquot class file. Changes have been made to udf class in order to leverage this new attribute in order to fetch reagent labels directly from class object instead of using genologics api.

2. Changes have been made to class ReagentRepositoryType to allow for validation of the return value of get_reagent_type()