### PR TITLE
Update requests-cache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests-cache==0.4.13
+requests-cache~=1.0.1
 openpyxl~=3.1.1


### PR DESCRIPTION
`requests-cache v0.4.13` is from 2016 and doesn't even support python > 3.5. This PR updates this package