### PR TITLE
LIMS-2476: allowing args to be passed to testing scripts

### DIFF
--- a/clarity_ext/context.py
+++ b/clarity_ext/context.py
@@ -31,7 +31,7 @@ class ExtensionContext(object):
     def __init__(self, session, artifact_service, file_service, current_user,
                  step_logger_service, step_repo, clarity_service, dilution_service, process_service,
                  validation_service, test_mode=False,
-                 disable_commits=False):
+                 disable_commits=False, **kwargs):
         """
         Initializes the context.
 
@@ -68,9 +68,10 @@ class ExtensionContext(object):
         self._calls_to_commit = 0
         self.validation_results = list()
         self.start = datetime.now()
+        self.kwargs = kwargs
 
     @staticmethod
-    def create(step_id, test_mode=False, uploaded_to_stdout=False, disable_commits=False):
+    def create(step_id, test_mode=False, uploaded_to_stdout=False, disable_commits=False, **kwargs):
         """
         Creates a context with all required services set up. This is the way
         a context is meant to be created in production and integration tests,
@@ -97,7 +98,7 @@ class ExtensionContext(object):
                                 step_logger_service, step_repo, clarity_service,
                                 dilution_service, process_service,
                                 validation_service,
-                                test_mode=test_mode, disable_commits=disable_commits)
+                                test_mode=test_mode, disable_commits=disable_commits, **kwargs)
 
     @staticmethod
     def create_mocked(session, step_repo, os_service, file_repository, clarity_service,

--- a/clarity_ext/extensions.py
+++ b/clarity_ext/extensions.py
@@ -138,7 +138,7 @@ class ExtensionService(object):
                 self._prepare_fresh_test(path)
 
             with utils.add_log_file_handler(os.path.join(path, "extensions.log"), False, ExtensionTestLogFilter()):
-                self._run(config, path, pid, module, artifacts_to_stdout, disable_context_commit=not commit, test_mode=True)
+                self._run(config, path, pid, module, artifacts_to_stdout, disable_context_commit=not commit, test_mode=True, run_arguments=run_arguments)
 
             if validate_against_frozen:
                 try:
@@ -273,7 +273,7 @@ class ExtensionService(object):
             context.commit_step_log_only()
             self._ensure_error_on_instance(instance, e)
 
-    def _run(self, config, path, pid, module, artifacts_to_stdout, disable_context_commit=False, test_mode=False):
+    def _run(self, config, path, pid, module, artifacts_to_stdout, disable_context_commit=False, test_mode=False, run_arguments={}):
         path = os.path.abspath(path)
         self.logger.info("Running extension {module} for pid={pid}, test_mode={test_mode}".format(
             module=module, pid=pid, test_mode=test_mode))
@@ -284,7 +284,8 @@ class ExtensionService(object):
         self.logger.info("Executing at {}".format(path))
         context = ExtensionContext.create(pid, test_mode=test_mode,
                                           disable_commits=disable_context_commit,
-                                          uploaded_to_stdout=artifacts_to_stdout)
+                                          uploaded_to_stdout=artifacts_to_stdout,
+                                          run_arguments=run_arguments)
 
         instance = extension(context, config, self)
 


### PR DESCRIPTION
This code allows for arguments to be passed while calling the test scripts. 
Only 'pid' and 'commit' arguments were been used and any other argument was not been passed to the test script been called.